### PR TITLE
Fixes for effects with do_strike

### DIFF
--- a/scenes/game/enums.gd
+++ b/scenes/game/enums.gd
@@ -117,6 +117,7 @@ enum EventType {
 	EventType_Strike_DodgeFromOppositeBuddy,
 	EventType_Strike_DoResponseNow,
 	EventType_Strike_EffectChoice,
+	EventType_Strike_EffectDoStrike,
 	EventType_Strike_ExUp,
 	EventType_Strike_ForceForArmor,
 	EventType_Strike_ForceWildSwing,

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -1993,6 +1993,17 @@ func _on_effect_choice(event):
 	else:
 		ai_effect_choice(event)
 
+func _on_effect_do_strike(event):
+	var player = event['event_player']
+	var strike_info = event['extra_info']
+	var card_id = strike_info['card_id']
+	var wild_swing = strike_info['wild_swing']
+	var ex_card_id = strike_info['ex_card_id']
+	if player == Enums.PlayerId.PlayerId_Player:
+		game_wrapper.submit_strike(player, card_id, wild_swing, ex_card_id)
+	else:
+		ai_strike_effect_do_strike(card_id, wild_swing, ex_card_id)
+
 func _on_pay_cost_gauge(event):
 	var player = event['event_player']
 	var enable_reminder = event['extra_info']
@@ -2242,6 +2253,8 @@ func _handle_events(events):
 				_on_strike_do_response_now(event)
 			Enums.EventType.EventType_Strike_EffectChoice:
 				_on_effect_choice(event)
+			Enums.EventType.EventType_Strike_EffectDoStrike:
+				_on_effect_do_strike(event)
 			Enums.EventType.EventType_Strike_ExUp:
 				delay = _stat_notice_event(event)
 			Enums.EventType.EventType_Strike_ForceForArmor:
@@ -3007,6 +3020,15 @@ func ai_strike_response():
 		change_ui_state(UIState.UIState_WaitForGameServer)
 	else:
 		print("FAILED AI STRIKE RESPONSE")
+
+func ai_strike_effect_do_strike(card_id : int, wild_swing : bool, ex_card_id : int):
+	change_ui_state(UIState.UIState_WaitForGameServer)
+	if not game_wrapper.is_ai_game(): return
+	var success = game_wrapper.submit_strike(Enums.PlayerId.PlayerId_Opponent, card_id, wild_swing, ex_card_id)
+	if success:
+		change_ui_state(UIState.UIState_WaitForGameServer)
+	else:
+		print("FAILED AI EFFECT CAUSED STRIKE")
 
 func ai_discard(event):
 	change_ui_state(UIState.UIState_WaitForGameServer)

--- a/scenes/game/local_game.gd
+++ b/scenes/game/local_game.gd
@@ -4364,6 +4364,7 @@ func boost_play_cleanup(events, performing_player : Player):
 		events += [create_event(Enums.EventType.EventType_ForceStartStrike, performing_player.my_id, 0)]
 		decision_info.type = Enums.DecisionType.DecisionType_StrikeNow
 		decision_info.player = performing_player.my_id
+		active_character_action = false
 
 	if active_boost.strike_after_boost and not active_strike:
 		if game_state != Enums.GameState.GameState_Strike_Opponent_Set_First:

--- a/test/unit/test_anji.gd
+++ b/test/unit/test_anji.gd
@@ -138,9 +138,11 @@ func execute_strike(initiator, defender, init_card : String, def_card : String, 
 		game_logic.do_force_for_effect(initiator, init_force_discard)
 
 	if reading_id != -1:
-		all_events += game_logic.get_latest_events()
 		assert_eq(game_logic.decision_info.type, Enums.DecisionType.DecisionType_ChooseSimultaneousEffect)
 		assert_true(game_logic.do_choice(defender, 0))
+		all_events += game_logic.get_latest_events()
+		validate_has_event(all_events, Enums.EventType.EventType_Strike_EffectDoStrike, defender, 0)
+		assert_true(game_logic.do_strike(defender, reading_id, false, -1))
 	elif def_ex:
 		give_player_specific_card(defender, def_card, TestCardId4)
 		all_events += do_strike_response(defender, TestCardId2, TestCardId4)


### PR DESCRIPTION
Calling do_strike from an effect confused entry points like do_choice, so I added a simple event that the effects can add instead. Jack-O's UA was also never indicating that it was done resolving; if there are any that cause strikes without an explicit effect call they may also be vulnerable to this at the moment