### PR TITLE
Prevent reading test from failing stochastically

### DIFF
--- a/test/unit/test_anji.gd
+++ b/test/unit/test_anji.gd
@@ -345,6 +345,8 @@ func test_anji_kachoufuugetsu_reading_correct():
 
 func test_anji_kachoufuugetsu_reading_incorrect():
 	position_players(player1, 3, player2, 4)
+	player2.hand = []
+	give_player_specific_card(player2, "gg_normal_sweep", TestCardId4)
 	var name_card_id = player2.hand[0].id
 	player2.hand = []
 	give_player_specific_card(player1, "anji_kachoufuugetsukai", TestCardId3)


### PR DESCRIPTION
I think this was happening because sometimes the first card in player 2's hand was not a normal
