### PR TITLE
Add UI describing plague knight discards

### DIFF
--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -1826,6 +1826,10 @@ func begin_strike_choosing(strike_response : bool, cancel_allowed : bool,
 	if cards_that_will_not_hit.size() > 0:
 		for card in cards_that_will_not_hit:
 			dialogue += "\n" + card + " will not hit."
+	var plague_knight_discard_names = game_wrapper.get_plague_knight_discard_names(Enums.PlayerId.PlayerId_Opponent)
+	if plague_knight_discard_names.size() > 0:
+		for card in plague_knight_discard_names:
+			dialogue += "\nPlague Knight discarded " + card +"."
 	enable_instructions_ui(dialogue, true, can_cancel, not disable_wild_swing, not disable_ex)
 	var new_sub_state
 	if strike_response:

--- a/scenes/game/game_wrapper.gd
+++ b/scenes/game/game_wrapper.gd
@@ -231,6 +231,14 @@ func get_will_not_hit_card_names(player_id : Enums.PlayerId) -> Array:
 			card_names.append(card_db.get_card_name_by_card_definition_id(card))
 	return card_names
 
+func get_plague_knight_discard_names(player_id : Enums.PlayerId) -> Array:
+	var card_names = []
+	var player = _get_player(player_id)
+	if player.plague_knight_discard_names.size() > 0:
+		for card in player.plague_knight_discard_names:
+			card_names.append(card)
+	return card_names
+
 func get_buddy_name(player_id : Enums.PlayerId, buddy_id : String):
 	return _get_player(player_id).get_buddy_name(buddy_id)
 

--- a/scenes/game/local_game.gd
+++ b/scenes/game/local_game.gd
@@ -487,6 +487,7 @@ class Player:
 	var guile_change_cards_bonus : bool
 	var cards_that_will_not_hit : Array[String]
 	var cards_invalid_during_strike : Array[String]
+	var plague_knight_discard_names : Array[String]
 
 	func _init(id, player_name, parent_ref, card_db_ref, chosen_deck, card_start_id):
 		my_id = id
@@ -567,6 +568,7 @@ class Player:
 		guile_change_cards_bonus = false
 		cards_that_will_not_hit = []
 		cards_invalid_during_strike = []
+		plague_knight_discard_names = []
 
 		if "buddy_cards" in deck_def:
 			var buddy_index = 0
@@ -2275,6 +2277,8 @@ func advance_to_next_turn():
 	opponent.cards_that_will_not_hit = []
 	player.cards_invalid_during_strike = []
 	opponent.cards_invalid_during_strike = []
+	player.plague_knight_discard_names = []
+	opponent.plague_knight_discard_names = []
 
 	# Update strike turn tracking
 	last_turn_was_strike = strike_happened_this_turn
@@ -3369,6 +3373,7 @@ func handle_strike_effect(card_id :int, effect, performing_player : Player):
 				events += performing_player.discard(cards_to_discard)
 				add_attack_triggers(performing_player, cards_to_discard, true)
 				var discarded_name = card_db.get_card_name(cards_to_discard[0])
+				performing_player.plague_knight_discard_names.append(discarded_name)
 				_append_log_full(Enums.LogType.LogType_CardInfo, performing_player, "discards random card: %s." % discarded_name)
 		"exceed_end_of_turn":
 			performing_player.exceed_at_end_of_turn = true


### PR DESCRIPTION
Maybe this + sidestep could eventually be extensible and add to some kind of array of messages to display in this location? I don't think that would be hard, and could also be good for Critical. Will think about it.

Results of this change:

![plague_knight_no_discard](https://github.com/daniel-k-taylor/exceedgameclient/assets/157657399/eb260547-f0d6-4099-865a-4420f20a1c99)

![plague_knight_frontside](https://github.com/daniel-k-taylor/exceedgameclient/assets/157657399/38658f80-5507-410f-9311-ef3a7fabf028)

![plague_knight_exceed](https://github.com/daniel-k-taylor/exceedgameclient/assets/157657399/42b24d98-2422-49b8-8744-b50eef86558d)