### PR TITLE
Cancellable Character Actions

### DIFF
--- a/data/decks/carlclover.json
+++ b/data/decks/carlclover.json
@@ -44,6 +44,7 @@
 		"requires_buddy_in_play": "true",
 		"buddy_id": "nirvana_active",
 		"buddy_name": "Nirvana",
+		"shortcut_effect_type": "move_buddy",
 		"effect": {
 			"effect_type": "move_buddy",
 			"buddy_id": "nirvana_active",
@@ -59,6 +60,7 @@
 		"requires_buddy_in_play": "true",
 		"buddy_id": "nirvana_active",
 		"buddy_name": "Nirvana",
+		"shortcut_effect_type": "move_buddy",
 		"effect": {
 			"effect_type": "move_buddy",
 			"strike_after": true,

--- a/data/decks/chaos.json
+++ b/data/decks/chaos.json
@@ -10,6 +10,7 @@
 	"character_action_default": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "strike",
 		"effect": {
 			"effect_type": "set_used_character_bonus",
 			"and": {
@@ -41,6 +42,7 @@
 			"force_cost": 0,
 			"min_hand_size": 1,
 			"action_name": "Revert",
+			"shortcut_effect_type": "gauge_from_hand",
 			"effect": {
 				"effect_type": "gauge_from_hand",
 				"min_amount": 1,

--- a/data/decks/enkidu.json
+++ b/data/decks/enkidu.json
@@ -30,6 +30,7 @@
 			"force_cost": 0,
 			"min_hand_size": 1,
 			"action_name": "Revert",
+			"shortcut_effect_type": "gauge_from_hand",
 			"effect": {
 				"effect_type": "gauge_from_hand",
 				"min_amount": 1,

--- a/data/decks/giovanna.json
+++ b/data/decks/giovanna.json
@@ -12,6 +12,7 @@
 	"character_action_default": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "strike",
 		"effect": {
 			"effect_type": "strike"
 		}

--- a/data/decks/hyde.json
+++ b/data/decks/hyde.json
@@ -46,6 +46,7 @@
 			"force_cost": 0,
 			"min_hand_size": 1,
 			"action_name": "Revert",
+			"shortcut_effect_type": "gauge_from_hand",
 			"effect": {
 				"effect_type": "gauge_from_hand",
 				"min_amount": 1,

--- a/data/decks/hyde.json
+++ b/data/decks/hyde.json
@@ -8,6 +8,7 @@
 	"character_action_default": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "choice",
 		"effect": {
 			"effect_type": "choice",
 			"choice": [

--- a/data/decks/linne.json
+++ b/data/decks/linne.json
@@ -29,6 +29,7 @@
 			"gauge_cost": 0,
 			"force_cost": 0,
 			"can_boost_continuous_boost_from_gauge": true,
+			"shortcut_effect_type": "boost_from_gauge",
 			"effect": {
 				"effect_type": "boost_from_gauge",
 				"limitation": "continuous"

--- a/data/decks/linne.json
+++ b/data/decks/linne.json
@@ -39,6 +39,7 @@
 			"force_cost": 0,
 			"min_hand_size": 1,
 			"action_name": "Revert",
+			"shortcut_effect_type": "gauge_from_hand",
 			"effect": {
 				"effect_type": "gauge_from_hand",
 				"min_amount": 1,

--- a/data/decks/litchi.json
+++ b/data/decks/litchi.json
@@ -44,6 +44,7 @@
 			"force_cost": 0,
 			"action_name": "Move Mantenbo",
 			"requires_buddy_in_play": "true",
+			"shortcut_effect_type": "move_buddy",
 			"effect": {
 				"condition": "buddy_in_play",
 				"condition_detail": "Mantenbo",
@@ -92,6 +93,7 @@
 			"force_cost": 0,
 			"action_name": "Move Mantenbo",
 			"requires_buddy_in_play": "true",
+			"shortcut_effect_type": "move_buddy",
 			"effect": {
 				"condition": "buddy_in_play",
 				"condition_detail": "Mantenbo",

--- a/data/decks/litchi.json
+++ b/data/decks/litchi.json
@@ -59,6 +59,7 @@
 			"force_cost": 0,
 			"action_name": "Summon/Remove Mantenbo",
 			"per_turn_limit": 1,
+			"shortcut_effect_type": "choice",
 			"effect": {
 				"effect_type": "choice",
 				"choice": [

--- a/data/decks/londrekia.json
+++ b/data/decks/londrekia.json
@@ -20,6 +20,7 @@
 	"character_action_default": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "strike",
 		"effect": {
 			"effect_type": "spend_all_gauge_and_save_amount",
 			"and": {
@@ -40,6 +41,7 @@
 			"force_cost": 0,
 			"min_hand_size": 1,
 			"action_name": "Revert",
+			"shortcut_effect_type": "gauge_from_hand",
 			"effect": {
 				"effect_type": "gauge_from_hand",
 				"min_amount": 1,

--- a/data/decks/mika.json
+++ b/data/decks/mika.json
@@ -7,6 +7,7 @@
 	"character_action_default": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "self_discard_choose",
 		"effect": {
 			"effect_type": "self_discard_choose",
 			"optional": false,

--- a/data/decks/mika.json
+++ b/data/decks/mika.json
@@ -39,6 +39,7 @@
 			"force_cost": 0,
 			"min_hand_size": 1,
 			"action_name": "Revert",
+			"shortcut_effect_type": "gauge_from_hand",
 			"effect": {
 				"effect_type": "gauge_from_hand",
 				"min_amount": 1,

--- a/data/decks/mole.json
+++ b/data/decks/mole.json
@@ -11,6 +11,7 @@
 	"character_action_default": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "place_buddy_at_range",
 		"effect": {
 			"effect_type": "place_buddy_at_range",
 			"buddy_name": "Burrow",
@@ -25,6 +26,7 @@
 	"character_action_exceeded": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "place_buddy_at_range",
 		"effect": {
 			"effect_type": "place_buddy_at_range",
 			"buddy_name": "Burrow",

--- a/data/decks/nanase.json
+++ b/data/decks/nanase.json
@@ -7,6 +7,7 @@
 	"character_action_default": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "strike",
 		"effect": {
 			"effect_type": "strike"
 		}
@@ -24,6 +25,7 @@
 			"force_cost": 0,
 			"min_hand_size": 1,
 			"action_name": "Revert",
+			"shortcut_effect_type": "gauge_from_hand",
 			"effect": {
 				"effect_type": "gauge_from_hand",
 				"min_amount": 1,

--- a/data/decks/phonon.json
+++ b/data/decks/phonon.json
@@ -16,7 +16,6 @@
 		{
 			"gauge_cost": 1,
 			"force_cost": 0,
-			"shortcut_effect_type": "strike",
 			"effect": {
 				"condition": "not_last_turn_was_strike",
 				"effect_type": "choice",

--- a/data/decks/phonon.json
+++ b/data/decks/phonon.json
@@ -7,6 +7,7 @@
 	"character_action_default": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "strike",
 		"effect": {
 			"effect_type": "strike"
 		}
@@ -15,6 +16,7 @@
 		{
 			"gauge_cost": 1,
 			"force_cost": 0,
+			"shortcut_effect_type": "strike",
 			"effect": {
 				"condition": "not_last_turn_was_strike",
 				"effect_type": "choice",

--- a/data/decks/phonon.json
+++ b/data/decks/phonon.json
@@ -35,6 +35,7 @@
 			"force_cost": 0,
 			"min_hand_size": 1,
 			"action_name": "Revert",
+			"shortcut_effect_type": "gauge_from_hand",
 			"effect": {
 				"effect_type": "gauge_from_hand",
 				"min_amount": 1,

--- a/data/decks/propeller.json
+++ b/data/decks/propeller.json
@@ -18,6 +18,7 @@
 		"gauge_cost": 0,
 		"force_cost": 0,
 		"action_name": "Move 1 and Strike",
+		"shortcut_effect_type": "choice",
 		"effect": {
 			"effect_type": "choice",
 			"choice": [

--- a/data/decks/rachel.json
+++ b/data/decks/rachel.json
@@ -56,6 +56,7 @@
 			"NOTE": "Once per turn force to close/retreat",
 			"gauge_cost": 0,
 			"force_cost": 0,
+			"shortcut_effect_type": "choice",
 			"per_turn_limit": 1,
 			"effect": {
 				"effect_type": "take_bonus_actions",
@@ -95,6 +96,7 @@
 			"gauge_cost": 0,
 			"force_cost": 0,
 			"per_turn_limit": 1,
+			"shortcut_effect_type": "choice",
 			"effect": {
 				"effect_type": "take_bonus_actions",
 				"silent_effect": true,

--- a/data/decks/seth.json
+++ b/data/decks/seth.json
@@ -8,6 +8,7 @@
 	"character_action_default": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "strike",
 		"effect": {
 			"effect_type": "strike"
 		}
@@ -25,6 +26,7 @@
 			"force_cost": 0,
 			"min_hand_size": 1,
 			"action_name": "Revert",
+			"shortcut_effect_type": "gauge_from_hand",
 			"effect": {
 				"effect_type": "gauge_from_hand",
 				"min_amount": 1,

--- a/data/decks/shovelshield.json
+++ b/data/decks/shovelshield.json
@@ -35,6 +35,7 @@
 	"character_action_exceeded": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "place_buddy_in_any_space",
 		"effect": {
 			"effect_type": "place_buddy_in_any_space",
 			"buddy_name": "Shield Knight"

--- a/data/decks/shovelshield.json
+++ b/data/decks/shovelshield.json
@@ -15,6 +15,7 @@
 	"character_action_default": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "choice",
 		"effect": {
 			"effect_type": "choice",
 			"choice": [

--- a/data/decks/yuzu.json
+++ b/data/decks/yuzu.json
@@ -7,6 +7,7 @@
 	"character_action_default": [{
 		"gauge_cost": 0,
 		"force_cost": 0,
+		"shortcut_effect_type": "gauge_from_hand",
 		"effect": {
 			"effect_type": "gauge_from_hand",
 			"min_amount": 1,
@@ -31,6 +32,7 @@
 			"force_cost": 0,
 			"min_hand_size": 1,
 			"action_name": "Revert",
+			"shortcut_effect_type": "gauge_from_hand",
 			"effect": {
 				"effect_type": "gauge_from_hand",
 				"min_amount": 1,

--- a/scenes/game/game_wrapper.gd
+++ b/scenes/game/game_wrapper.gd
@@ -270,6 +270,38 @@ func get_plague_knight_discard_names(player_id : Enums.PlayerId) -> Array:
 func get_buddy_name(player_id : Enums.PlayerId, buddy_id : String):
 	return _get_player(player_id).get_buddy_name(buddy_id)
 
+func get_valid_locations_for_buddy_effect(player_id : Enums.PlayerId, effect : Dictionary):
+	var MinArenaLocation = 1
+	var MaxArenaLocation = 9
+	var locations = []
+
+	var player = _get_player(player_id)
+	var effect_type = effect['effect_type']
+	var buddy_id = ""
+	if 'buddy_id' in effect:
+		buddy_id = effect['buddy_id']
+
+	if effect_type == 'place_buddy_in_any_space':
+		for i in range(MinArenaLocation, MaxArenaLocation + 1):
+			locations.append(i)
+	elif effect_type == 'move_buddy':
+		var min_spaces = effect['amount']
+		var max_spaces = effect['amount2']
+		var buddy_location = player.get_buddy_location(buddy_id)
+		for i in range(MinArenaLocation, MaxArenaLocation + 1):
+			var distance = abs(buddy_location - i)
+			if distance >= min_spaces and distance <= max_spaces:
+				locations.append(i)
+	elif effect_type == 'place_buddy_at_range':
+		var range_min = effect['range_min']
+		var range_max = effect['range_max']
+		for i in range(MinArenaLocation, MaxArenaLocation + 1):
+			var range_origin = player.get_closest_occupied_space_to(i)
+			var distance = abs(range_origin - i)
+			if distance >= range_min and distance <= range_max:
+				locations.append(i)
+	return locations
+
 func get_card_index_in_discards(player_id : Enums.PlayerId, card_id : int):
 	var player = _get_player(player_id)
 	for i in range(len(player.discards)):

--- a/scenes/game/game_wrapper.gd
+++ b/scenes/game/game_wrapper.gd
@@ -114,6 +114,21 @@ func get_player_mulligan_complete(id):
 func get_player_character_action(id, action_idx = 0):
 	return _get_player(id).get_character_action(action_idx)
 
+func get_player_character_action_shortcut_effect(id, action_idx = 0):
+	var character_action = get_player_character_action(id, action_idx)
+	if 'shortcut_effect_type' in character_action:
+		var shortcut_effect_type = character_action['shortcut_effect_type']
+		var found_effect = character_action['effect']
+		var continue_searching = true
+		while continue_searching:
+			continue_searching = false
+			if found_effect['effect_type'] == shortcut_effect_type:
+				return found_effect
+			elif 'and' in found_effect:
+				found_effect = found_effect['and']
+				continue_searching = true
+	return {}
+
 func get_player_character_action_count(id):
 	return _get_player(id).get_character_action_count()
 


### PR DESCRIPTION
- Made it so that some UAs can be cancelled before you actually make the first decision
- Of those, made some UAs accessible through the "shortcut menu" when you select cards while picking an action
I generally avoided applying this to UAs with a force/gauge cost, since the ordering would get weird and you can cancel those already anyway

Strike UAs (in shortcut)
- Chaos (default)
- Gio (default)
- Londrekia (default)
- Nanase (default)
- Phonon (default)
- Seth (default)

Gauge-From-Hand UAs (in shortcut)
- S6 Revert
- Yuzuriha (default)

Boost from Gauge UAs (in shortcut)
- Linne (exceed)

Choose Discard UAs (in shortcut)
- MIka (default)

UAs beginning with a choice
- Hyde (default)
- Litchi (summon/remove mantenbo)
- Propeller Knight (exceed)
- Rachel
- Shovel/Shield Knight (default)

Buddy-placement UAs
- Carl
- Litchi (move mantenbo)
- Mole Knight
- Shovel/Shield Knight (exceed)