### PR TITLE
Remember most recently selected character between game sessions

### DIFF
--- a/globals/global_settings.gd
+++ b/globals/global_settings.gd
@@ -11,6 +11,7 @@ const CharacterBanlist = ['carmine']
 var BGMEnabled = true
 var DefaultPlayerName = ""
 var GameSoundsEnabled = true
+var PlayerCharacter = ""
 
 const user_settings_file = "user://settings.json"
 
@@ -48,13 +49,17 @@ func load_persistent_settings():
 		DefaultPlayerName = json['DefaultPlayerName']
 	if 'GameSoundsEnabled' in json and json['GameSoundsEnabled'] is bool:
 		GameSoundsEnabled = json['GameSoundsEnabled']
-
+	if 'PlayerCharacter' in json and json['PlayerCharacter'] is String:
+		PlayerCharacter = json['PlayerCharacter']
+	else:
+		PlayerCharacter = 'solbadguy'
 
 func save_persistent_settings():
 	var settings = {
 		"BGMEnabled": BGMEnabled,
 		"DefaultPlayerName": DefaultPlayerName,
-		"GameSoundsEnabled": GameSoundsEnabled
+		"GameSoundsEnabled": GameSoundsEnabled,
+		"PlayerCharacter": PlayerCharacter
 	}
 
 	var file = FileAccess.open(user_settings_file, FileAccess.WRITE)
@@ -70,4 +75,8 @@ func set_game_sounds_enabled(value : bool):
 
 func set_player_name(value : String):
 	DefaultPlayerName = value
+	save_persistent_settings()
+
+func set_player_character(value: String):
+	PlayerCharacter = value
 	save_persistent_settings()

--- a/globals/global_settings.gd
+++ b/globals/global_settings.gd
@@ -34,10 +34,10 @@ func get_server_url() -> String:
 	else:
 		return local_url
 
-func load_persistent_settings():
+func load_persistent_settings() -> bool:  # returns success code
 	if not FileAccess.file_exists(user_settings_file):
 		print("Unable to load settings file.")
-		return # Error! We don't have a save to load.
+		return false # Error! We don't have a save to load.
 
 	var file = FileAccess.open(user_settings_file, FileAccess.READ)
 	var text = file.get_as_text()
@@ -49,17 +49,18 @@ func load_persistent_settings():
 		DefaultPlayerName = json['DefaultPlayerName']
 	if 'GameSoundsEnabled' in json and json['GameSoundsEnabled'] is bool:
 		GameSoundsEnabled = json['GameSoundsEnabled']
-	if 'PlayerCharacter' in json and json['PlayerCharacter'] is String:
+	if 'PlayerCharacter' in json and json['PlayerCharacter'] is String and not json['PlayerCharacter'].is_empty():
 		PlayerCharacter = json['PlayerCharacter']
 	else:
 		PlayerCharacter = 'solbadguy'
+	return true
 
 func save_persistent_settings():
 	var settings = {
 		"BGMEnabled": BGMEnabled,
 		"DefaultPlayerName": DefaultPlayerName,
 		"GameSoundsEnabled": GameSoundsEnabled,
-		"PlayerCharacter": PlayerCharacter
+		"PlayerCharacter": PlayerCharacter,
 	}
 
 	var file = FileAccess.open(user_settings_file, FileAccess.WRITE)

--- a/scenes/menu/main_menu.gd
+++ b/scenes/menu/main_menu.gd
@@ -309,28 +309,30 @@ func update_char(char_id: String, is_player: bool) -> void:
 	var label = player_char_label if is_player else opponent_char_label
 	var portrait = player_char_portrait if is_player else opponent_char_portrait
 	var display_name = "Random"
-	if char_id == "random_s7":
-		char_id = "random"
-	elif char_id == "random_s6":
-		char_id = "unilogo"
-	elif char_id == "random_s5":
-		char_id = "blazbluelogo2"
-	elif char_id == "random_s4":
-		char_id = "sklogo"
-	elif char_id == "random_s3":
-		char_id = "sflogo"
-	elif char_id == "random":
-		char_id = "exceedrandom"
-	else:
-		var deck = CardDefinitions.get_deck_from_str_id(char_id)
-		display_name = deck['display_name']
-	label.text = display_name
-	portrait.texture = load("res://assets/portraits/" + char_id + ".png")
 	if is_player:
 		player_selected_character = char_id
 		GlobalSettings.set_player_character(char_id)
 	else:
 		opponent_selected_character = char_id
+	var portrait_id: String
+	if char_id == "random_s7":
+		portrait_id = "random"
+	elif char_id == "random_s6":
+		portrait_id = "unilogo"
+	elif char_id == "random_s5":
+		portrait_id = "blazbluelogo2"
+	elif char_id == "random_s4":
+		portrait_id = "sklogo"
+	elif char_id == "random_s3":
+		portrait_id = "sflogo"
+	elif char_id == "random":
+		portrait_id = "exceedrandom"
+	else:
+		var deck = CardDefinitions.get_deck_from_str_id(char_id)
+		display_name = deck['display_name']
+		portrait_id = char_id
+	label.text = display_name
+	portrait.texture = load("res://assets/portraits/" + portrait_id + ".png")
 	if len(display_name) <= label_length_threshold:
 		label.set("theme_override_font_sizes/font_size", label_font_normal)
 	else:

--- a/scenes/menu/main_menu.gd
+++ b/scenes/menu/main_menu.gd
@@ -67,6 +67,7 @@ func _ready():
 	modal_list.visible = false
 
 func settings_loaded():
+	player_selected_character = GlobalSettings.PlayerCharacter
 	bgm_checkbox.button_pressed = GlobalSettings.BGMEnabled
 	game_sound_checkbox.button_pressed = GlobalSettings.GameSoundsEnabled
 	start_music()
@@ -304,7 +305,7 @@ func _on_matchmake_button_pressed():
 func _on_char_select_close_character_select():
 	char_select.visible = false
 
-func update_char(label, portrait, char_id):
+func update_char(label, portrait, char_id, save: bool):
 	var display_name = "Random"
 	if char_id == "random_s7":
 		char_id = "random"
@@ -323,6 +324,8 @@ func update_char(label, portrait, char_id):
 		display_name = deck['display_name']
 	label.text = display_name
 	portrait.texture = load("res://assets/portraits/" + char_id + ".png")
+	if save:
+		GlobalSettings.set_player_character(char_id)
 	if len(display_name) <= label_length_threshold:
 		label.set("theme_override_font_sizes/font_size", label_font_normal)
 	else:
@@ -331,10 +334,10 @@ func update_char(label, portrait, char_id):
 func _on_char_select_select_character(char_id):
 	if selecting_player:
 		player_selected_character = char_id
-		update_char(player_char_label, player_char_portrait, char_id)
+		update_char(player_char_label, player_char_portrait, char_id, true)
 	else:
-		opponent_selected_character =char_id
-		update_char(opponent_char_label, opponent_char_portrait, char_id)
+		opponent_selected_character = char_id
+		update_char(opponent_char_label, opponent_char_portrait, char_id, false)
 	_on_char_select_close_character_select()
 
 func _on_change_player_character_button_pressed(is_player : bool):

--- a/scenes/menu/main_menu.gd
+++ b/scenes/menu/main_menu.gd
@@ -305,7 +305,10 @@ func _on_matchmake_button_pressed():
 func _on_char_select_close_character_select():
 	char_select.visible = false
 
-func update_char(label, portrait, char_id, save: bool):
+func update_char(char_id, is_player: bool):
+	var label = player_char_label if is_player else opponent_char_label
+	var portrait = player_char_portrait if is_player else opponent_char_portrait
+
 	var display_name = "Random"
 	if char_id == "random_s7":
 		char_id = "random"
@@ -324,20 +327,18 @@ func update_char(label, portrait, char_id, save: bool):
 		display_name = deck['display_name']
 	label.text = display_name
 	portrait.texture = load("res://assets/portraits/" + char_id + ".png")
-	if save:
+	if is_player:
+		player_selected_character = char_id
 		GlobalSettings.set_player_character(char_id)
+	else:
+		opponent_selected_character = char_id
 	if len(display_name) <= label_length_threshold:
 		label.set("theme_override_font_sizes/font_size", label_font_normal)
 	else:
 		label.set("theme_override_font_sizes/font_size", label_font_small)
 
 func _on_char_select_select_character(char_id):
-	if selecting_player:
-		player_selected_character = char_id
-		update_char(player_char_label, player_char_portrait, char_id, true)
-	else:
-		opponent_selected_character = char_id
-		update_char(opponent_char_label, opponent_char_portrait, char_id, false)
+	update_char(char_id, selecting_player)
 	_on_char_select_close_character_select()
 
 func _on_change_player_character_button_pressed(is_player : bool):

--- a/scenes/menu/main_menu.gd
+++ b/scenes/menu/main_menu.gd
@@ -305,10 +305,9 @@ func _on_matchmake_button_pressed():
 func _on_char_select_close_character_select():
 	char_select.visible = false
 
-func update_char(char_id, is_player: bool):
+func update_char(char_id: String, is_player: bool) -> void:
 	var label = player_char_label if is_player else opponent_char_label
 	var portrait = player_char_portrait if is_player else opponent_char_portrait
-
 	var display_name = "Random"
 	if char_id == "random_s7":
 		char_id = "random"

--- a/scenes/menu/main_menu.gd
+++ b/scenes/menu/main_menu.gd
@@ -67,7 +67,7 @@ func _ready():
 	modal_list.visible = false
 
 func settings_loaded():
-	player_selected_character = GlobalSettings.PlayerCharacter
+	player_selected_character = GlobalSettings.PlayerCharacter or "solbadguy"
 	update_char(player_selected_character, true)
 	bgm_checkbox.button_pressed = GlobalSettings.BGMEnabled
 	game_sound_checkbox.button_pressed = GlobalSettings.GameSoundsEnabled

--- a/scenes/menu/main_menu.gd
+++ b/scenes/menu/main_menu.gd
@@ -68,6 +68,7 @@ func _ready():
 
 func settings_loaded():
 	player_selected_character = GlobalSettings.PlayerCharacter
+	update_char(player_selected_character, true)
 	bgm_checkbox.button_pressed = GlobalSettings.BGMEnabled
 	game_sound_checkbox.button_pressed = GlobalSettings.GameSoundsEnabled
 	start_music()

--- a/scenes/menu/main_menu.gd
+++ b/scenes/menu/main_menu.gd
@@ -67,7 +67,7 @@ func _ready():
 	modal_list.visible = false
 
 func settings_loaded():
-	player_selected_character = GlobalSettings.PlayerCharacter or "solbadguy"
+	player_selected_character = GlobalSettings.PlayerCharacter if GlobalSettings.PlayerCharacter else "solbadguy"
 	update_char(player_selected_character, true)
 	bgm_checkbox.button_pressed = GlobalSettings.BGMEnabled
 	game_sound_checkbox.button_pressed = GlobalSettings.GameSoundsEnabled


### PR DESCRIPTION
This only affects character select behavior when the game is opened. The setting is already retained between matches in a single session.

Tested: Using manual edits to user://settings.json -- works with:
  * Missing new PlayerCharacter attribute (as will be the case for all clients the first time they see this update) -- default to Sol
  * Empty string -- default to Sol
  * Set to 'potemkin' -- default to Potemkin, starting a match without interacting with character select correctly uses Potemkin (i.e. the use of the default setting is not just cosmetic)