### PR TITLE
Pull common unit testing functions to a parent class and refactor

### DIFF
--- a/globals/card_definitions.gd
+++ b/globals/card_definitions.gd
@@ -4,7 +4,7 @@ var card_data = []
 
 var card_definitions_path = "res://data/card_definitions.json"
 var decks_path = "res://data/decks"
-var decks = []
+var decks = []  # An array of (JSON) dictionaries
 
 const CardHighlightColor = "#7DF9FF" # Light blue
 

--- a/scenes/game/enums.gd
+++ b/scenes/game/enums.gd
@@ -1,3 +1,4 @@
+class_name Enums
 extends Node
 
 enum PlayerId {
@@ -21,17 +22,17 @@ enum DecisionType {
 	DecisionType_BoostNow,
 	DecisionType_ChooseArenaLocationForEffect,
 	DecisionType_ChooseDiscardContinuousBoost,
-	DecisionType_ChooseDiscardOpponentGauge,
+	DecisionType_ChooseDiscardOpponentGauge,  # 5
 	DecisionType_ChooseFromBoosts,
 	DecisionType_ChooseFromDiscard,
 	DecisionType_ChooseFromTopDeck,
 	DecisionType_ChooseSimultaneousEffect,
-	DecisionType_EffectChoice,
+	DecisionType_EffectChoice,  # 10
 	DecisionType_ForceBoostSustainTopdeck,
 	DecisionType_ForceBoostSustainTopDiscard,
 	DecisionType_ForceForEffect,
 	DecisionType_GaugeForEffect,
-	DecisionType_NameCard_OpponentDiscards,
+	DecisionType_NameCard_OpponentDiscards,  # 15
 	DecisionType_ChooseToDiscard,
 	DecisionType_PayStrikeCost_Required,
 	DecisionType_PayStrikeCost_CanWild,
@@ -72,102 +73,102 @@ enum EventType {
 	EventType_AddToDeck,
 	EventType_AddToHand,
 	EventType_AddToOverdrive,
-	EventType_AdvanceTurn,
+	EventType_AdvanceTurn,     # 5
 	EventType_BecomeWide,
 	EventType_BlockMovement,
 	EventType_Boost_ActionAfterBoost,
 	EventType_Boost_CancelDecision,
-	EventType_Boost_DiscardContinuousChoice,
+	EventType_Boost_DiscardContinuousChoice,  # 10
 	EventType_Boost_DiscardOpponentGauge,
 	EventType_Boost_Played,
 	EventType_Boost_Canceled,
 	EventType_Boost_Continuous_Added,
-	EventType_Boost_NameCardOpponentDiscards,
+	EventType_Boost_NameCardOpponentDiscards, # 15
 	EventType_Boost_Sidestep,
 	EventType_Boost_ZeroVector,
 	EventType_CardFromHandToGauge_Choice,
 	EventType_ChangeCards,
-	EventType_CharacterAction,
+	EventType_CharacterAction,                # 20
 	EventType_ChooseArenaLocationForEffect,
 	EventType_ChooseFromBoosts,
 	EventType_ChooseFromDiscard,
 	EventType_ChooseFromTopDeck,
-	EventType_ChooseOpponentCardToDiscard,
+	EventType_ChooseOpponentCardToDiscard,    # 25
 	EventType_Draw,
 	EventType_Emote,
 	EventType_EffectDoBoost,
 	EventType_Exceed,
-	EventType_ExceedRevert,
+	EventType_ExceedRevert,          # 30
 	EventType_ForceForEffect,
 	EventType_GaugeForEffect,
 	EventType_ForceStartBoost,
 	EventType_ForceStartStrike,
-	EventType_GameOver,
+	EventType_GameOver,              # 35
 	EventType_HandSizeExceeded,
 	EventType_Move,
 	EventType_MulliganDecision,
 	EventType_PickNumberFromRange,
-	EventType_PlaceBuddy,
+	EventType_PlaceBuddy,            # 40
 	EventType_PlaceCardUnderBoost,
 	EventType_PlaceLightningRod,
 	EventType_Prepare,
 	EventType_ReadingNormal,
-	EventType_ReshuffleDeck,
+	EventType_ReshuffleDeck,         # 45
 	EventType_ReshuffleDeck_Mulligan,
 	EventType_ReshuffleDiscard,
 	EventType_ReshuffleDiscardInPlace,
 	EventType_RevealCard,
-	EventType_RevealHand,
+	EventType_RevealHand,            # 50
 	EventType_RevealRandomGauge,
 	EventType_RevealStrike_OnePlayer,
 	EventType_RevealTopDeck,
 	EventType_Seal,
-	EventType_SetCardAside,
+	EventType_SetCardAside,          # 55
 	EventType_Strike_ArmorUp,
 	EventType_Strike_AttackDoesNotHit,
 	EventType_Strike_CardActivation,
 	EventType_Strike_CharacterEffect,
-	EventType_Strike_Critical,
+	EventType_Strike_Critical,       # 60
 	EventType_Strike_DodgeAttacks,
 	EventType_Strike_DodgeAttacksAtRange,
 	EventType_Strike_DodgeFromOppositeBuddy,
 	EventType_Strike_DoResponseNow,
-	EventType_Strike_EffectChoice,
+	EventType_Strike_EffectChoice,   # 65
 	EventType_Strike_EffectDoStrike,
 	EventType_Strike_ExUp,
 	EventType_Strike_ForceForArmor,
 	EventType_Strike_ForceWildSwing,
-	EventType_Strike_FromGauge,
+	EventType_Strike_FromGauge,      # 70
 	EventType_Strike_GainAdvantage,
 	EventType_Strike_GainLife,
 	EventType_Strike_GuardUp,
 	EventType_Strike_IgnoredPushPull,
-	EventType_Strike_Miss,
+	EventType_Strike_Miss,           # 75
 	EventType_Strike_ChooseToDiscard,
 	EventType_Strike_ChooseToDiscard_Info,
 	EventType_Strike_Cleanup,
 	EventType_Strike_OpponentCantMovePast,
-	EventType_Strike_OpponentSetsFirst,
+	EventType_Strike_OpponentSetsFirst,    # 80
 	EventType_Strike_OpponentSetsFirst_DefenderSet,
 	EventType_Strike_OpponentSetsFirst_InitiatorSet,
 	EventType_Strike_PayCost_Gauge,
 	EventType_Strike_PayCost_Force,
-	EventType_Strike_PayCost_Unable,
+	EventType_Strike_PayCost_Unable, # 85
 	EventType_Strike_PowerUp,
 	EventType_Strike_RandomGaugeStrike,
 	EventType_Strike_RangeUp,
 	EventType_Strike_Response,
-	EventType_Strike_Response_Ex,
+	EventType_Strike_Response_Ex,    # 90
 	EventType_Strike_Reveal,
 	EventType_Strike_SpeedUp,
 	EventType_Strike_SetX,
 	EventType_Strike_Started,
-	EventType_Strike_Started_Ex,
+	EventType_Strike_Started_Ex,     # 95
 	EventType_Strike_Started_ExtraAttack,
 	EventType_Strike_Stun,
 	EventType_Strike_Stun_Immunity,
 	EventType_Strike_TookDamage,
-	EventType_Strike_WildStrike,
+	EventType_Strike_WildStrike,     # 100
 	EventType_SustainBoost,
 	EventType_SwapSealedAndDeck,
 }

--- a/scenes/game/enums.gd
+++ b/scenes/game/enums.gd
@@ -1,4 +1,3 @@
-class_name Enums
 extends Node
 
 enum PlayerId {
@@ -22,17 +21,17 @@ enum DecisionType {
 	DecisionType_BoostNow,
 	DecisionType_ChooseArenaLocationForEffect,
 	DecisionType_ChooseDiscardContinuousBoost,
-	DecisionType_ChooseDiscardOpponentGauge,  # 5
+	DecisionType_ChooseDiscardOpponentGauge,
 	DecisionType_ChooseFromBoosts,
 	DecisionType_ChooseFromDiscard,
 	DecisionType_ChooseFromTopDeck,
 	DecisionType_ChooseSimultaneousEffect,
-	DecisionType_EffectChoice,  # 10
+	DecisionType_EffectChoice,
 	DecisionType_ForceBoostSustainTopdeck,
 	DecisionType_ForceBoostSustainTopDiscard,
 	DecisionType_ForceForEffect,
 	DecisionType_GaugeForEffect,
-	DecisionType_NameCard_OpponentDiscards,  # 15
+	DecisionType_NameCard_OpponentDiscards,
 	DecisionType_ChooseToDiscard,
 	DecisionType_PayStrikeCost_Required,
 	DecisionType_PayStrikeCost_CanWild,
@@ -73,102 +72,102 @@ enum EventType {
 	EventType_AddToDeck,
 	EventType_AddToHand,
 	EventType_AddToOverdrive,
-	EventType_AdvanceTurn,     # 5
+	EventType_AdvanceTurn,
 	EventType_BecomeWide,
 	EventType_BlockMovement,
 	EventType_Boost_ActionAfterBoost,
 	EventType_Boost_CancelDecision,
-	EventType_Boost_DiscardContinuousChoice,  # 10
+	EventType_Boost_DiscardContinuousChoice,
 	EventType_Boost_DiscardOpponentGauge,
 	EventType_Boost_Played,
 	EventType_Boost_Canceled,
 	EventType_Boost_Continuous_Added,
-	EventType_Boost_NameCardOpponentDiscards, # 15
+	EventType_Boost_NameCardOpponentDiscards,
 	EventType_Boost_Sidestep,
 	EventType_Boost_ZeroVector,
 	EventType_CardFromHandToGauge_Choice,
 	EventType_ChangeCards,
-	EventType_CharacterAction,                # 20
+	EventType_CharacterAction,
 	EventType_ChooseArenaLocationForEffect,
 	EventType_ChooseFromBoosts,
 	EventType_ChooseFromDiscard,
 	EventType_ChooseFromTopDeck,
-	EventType_ChooseOpponentCardToDiscard,    # 25
+	EventType_ChooseOpponentCardToDiscard,
 	EventType_Draw,
 	EventType_Emote,
 	EventType_EffectDoBoost,
 	EventType_Exceed,
-	EventType_ExceedRevert,          # 30
+	EventType_ExceedRevert,
 	EventType_ForceForEffect,
 	EventType_GaugeForEffect,
 	EventType_ForceStartBoost,
 	EventType_ForceStartStrike,
-	EventType_GameOver,              # 35
+	EventType_GameOver,
 	EventType_HandSizeExceeded,
 	EventType_Move,
 	EventType_MulliganDecision,
 	EventType_PickNumberFromRange,
-	EventType_PlaceBuddy,            # 40
+	EventType_PlaceBuddy,
 	EventType_PlaceCardUnderBoost,
 	EventType_PlaceLightningRod,
 	EventType_Prepare,
 	EventType_ReadingNormal,
-	EventType_ReshuffleDeck,         # 45
+	EventType_ReshuffleDeck,
 	EventType_ReshuffleDeck_Mulligan,
 	EventType_ReshuffleDiscard,
 	EventType_ReshuffleDiscardInPlace,
 	EventType_RevealCard,
-	EventType_RevealHand,            # 50
+	EventType_RevealHand,
 	EventType_RevealRandomGauge,
 	EventType_RevealStrike_OnePlayer,
 	EventType_RevealTopDeck,
 	EventType_Seal,
-	EventType_SetCardAside,          # 55
+	EventType_SetCardAside,
 	EventType_Strike_ArmorUp,
 	EventType_Strike_AttackDoesNotHit,
 	EventType_Strike_CardActivation,
 	EventType_Strike_CharacterEffect,
-	EventType_Strike_Critical,       # 60
+	EventType_Strike_Critical,
 	EventType_Strike_DodgeAttacks,
 	EventType_Strike_DodgeAttacksAtRange,
 	EventType_Strike_DodgeFromOppositeBuddy,
 	EventType_Strike_DoResponseNow,
-	EventType_Strike_EffectChoice,   # 65
+	EventType_Strike_EffectChoice,
 	EventType_Strike_EffectDoStrike,
 	EventType_Strike_ExUp,
 	EventType_Strike_ForceForArmor,
 	EventType_Strike_ForceWildSwing,
-	EventType_Strike_FromGauge,      # 70
+	EventType_Strike_FromGauge,
 	EventType_Strike_GainAdvantage,
 	EventType_Strike_GainLife,
 	EventType_Strike_GuardUp,
 	EventType_Strike_IgnoredPushPull,
-	EventType_Strike_Miss,           # 75
+	EventType_Strike_Miss,
 	EventType_Strike_ChooseToDiscard,
 	EventType_Strike_ChooseToDiscard_Info,
 	EventType_Strike_Cleanup,
 	EventType_Strike_OpponentCantMovePast,
-	EventType_Strike_OpponentSetsFirst,    # 80
+	EventType_Strike_OpponentSetsFirst,
 	EventType_Strike_OpponentSetsFirst_DefenderSet,
 	EventType_Strike_OpponentSetsFirst_InitiatorSet,
 	EventType_Strike_PayCost_Gauge,
 	EventType_Strike_PayCost_Force,
-	EventType_Strike_PayCost_Unable, # 85
+	EventType_Strike_PayCost_Unable,
 	EventType_Strike_PowerUp,
 	EventType_Strike_RandomGaugeStrike,
 	EventType_Strike_RangeUp,
 	EventType_Strike_Response,
-	EventType_Strike_Response_Ex,    # 90
+	EventType_Strike_Response_Ex,
 	EventType_Strike_Reveal,
 	EventType_Strike_SpeedUp,
 	EventType_Strike_SetX,
 	EventType_Strike_Started,
-	EventType_Strike_Started_Ex,     # 95
+	EventType_Strike_Started_Ex,
 	EventType_Strike_Started_ExtraAttack,
 	EventType_Strike_Stun,
 	EventType_Strike_Stun_Immunity,
 	EventType_Strike_TookDamage,
-	EventType_Strike_WildStrike,     # 100
+	EventType_Strike_WildStrike,
 	EventType_SustainBoost,
 	EventType_SwapSealedAndDeck,
 }

--- a/scenes/game/game_card.gd
+++ b/scenes/game/game_card.gd
@@ -1,3 +1,4 @@
+class_name GameCard
 extends Node
 
 var id

--- a/scenes/game/local_game.gd
+++ b/scenes/game/local_game.gd
@@ -1,3 +1,4 @@
+class_name LocalGame
 extends Node2D
 
 const Enums = preload("res://scenes/game/enums.gd")
@@ -43,7 +44,7 @@ const StrikeStaticConditions = [
 	"canceled_this_turn",
 ]
 
-var event_queue = []
+var event_queue = []  # This is purely a logging utility
 
 func get_latest_events() -> Array:
 	var events = event_queue

--- a/scenes/game/local_game.gd
+++ b/scenes/game/local_game.gd
@@ -44,7 +44,7 @@ const StrikeStaticConditions = [
 	"canceled_this_turn",
 ]
 
-var event_queue = []  # This is purely a logging utility
+var event_queue = []
 
 func get_latest_events() -> Array:
 	var events = event_queue

--- a/test/exceed_test.gd
+++ b/test/exceed_test.gd
@@ -8,9 +8,9 @@ var player1 : LocalGame.Player
 var player2 : LocalGame.Player
 
 ### !!! IMPORTANT
-# Subclasses must override this function
+# Subclasses must override this function to return a character name
 func who_am_i():
-	return "no-one-lmao"
+	return "override-who_am_i()-with-a-character-name-pls"
 
 func next_id():
 	next_test_card_id += 1
@@ -184,7 +184,7 @@ func process_remaining_decisions(initiator, defender, init_choices, def_choices)
 					" choices %s or defender choices %s" % [init_choices, def_choices])
 			return
 		while game_logic.game_state == Enums.GameState.GameState_PlayerDecision:
-				## TODO: Figure out if it's really necessary to limit ourselves to this decision type
+				## TODO: Figure out if it's really necessary to limit ourselves to this game state
 				# and game_logic.decision_info.type == Enums.DecisionType.DecisionType_ChooseSimultaneousEffect:
 			empty_loop_count = 0  # reset the count each time we actually get into this loop; it is not empty
 			var decision = game_logic.decision_info
@@ -228,8 +228,9 @@ func execute_strike(initiator, defender, init_card: String, def_card: String,
 	var init_card_ex_id = -1
 	var def_card_id = -1
 	var def_card_ex_id = -1
-	## TODO: Because all the card IDs are generated internally and at runtime, it is hard
-	##   to pass those IDs in through *_choices
+	## TODO: Figure out what to do if one of the *_choices needs to use a card
+	##   ID that will not be assigned until the `give_player_specific_card`
+	##   calls below.
 	if init_card:
 		init_card_id = give_player_specific_card(initiator, init_card)
 		if init_ex:

--- a/test/exceed_test.gd
+++ b/test/exceed_test.gd
@@ -1,0 +1,279 @@
+class_name ExceedGutTest
+extends GutTest
+
+var game_logic : LocalGame
+var next_test_card_id = 50000
+
+var player1 : LocalGame.Player
+var player2 : LocalGame.Player
+
+### !!! IMPORTANT
+# Subclasses must override this function
+func who_am_i():
+	return "no-one-lmao"
+
+func next_id():
+	next_test_card_id += 1
+	return next_test_card_id - 1
+
+func default_game_setup(alt_opponent : String = ""):
+	var default_deck = CardDefinitions.get_deck_from_str_id(who_am_i())
+	var opponent_deck = default_deck
+	if alt_opponent:
+		opponent_deck = CardDefinitions.get_deck_from_str_id(alt_opponent)
+	game_logic = LocalGame.new()
+	var seed_value = randi()
+	game_logic.initialize_game(default_deck, opponent_deck, "p1", "p2",
+			Enums.PlayerId.PlayerId_Player, seed_value)
+	game_logic.draw_starting_hands_and_begin()
+	game_logic.do_mulligan(game_logic.player, [])
+	game_logic.do_mulligan(game_logic.opponent, [])
+	player1 = game_logic.player
+	player2 = game_logic.opponent
+	game_logic.get_latest_events()  # just to clear the event queue
+
+func give_player_specific_card(player, def_id):
+	var card_def = CardDefinitions.get_card(def_id)
+	var card_id = next_id()
+	var card = GameCard.new(card_id, card_def, "image", player.my_id)
+	var card_db = game_logic.get_card_database()
+	card_db._test_insert_card(card)
+	player.hand.append(card)
+	return card_id
+
+func give_specific_cards(p1, id1, p2, id2):
+	var test_ids = []
+	if p1 and id1:
+		test_ids.append(give_player_specific_card(p1, id1))
+	if p2 and id2:
+		test_ids.append(give_player_specific_card(p2, id2))
+	return test_ids
+
+func position_players(p1, loc1, p2, loc2):
+	p1.arena_location = loc1
+	p2.arena_location = loc2
+
+func give_gauge(player, amount):
+	var card_ids = []
+	for i in range(amount):
+		player.add_to_gauge(player.deck[0])
+		card_ids.append(player.deck[0].id)
+		player.deck.remove_at(0)
+	return card_ids
+
+func validate_has_event(events, event_type, target_player, number = null):
+	for event in events:
+		if event['event_type'] == event_type:
+			if event['event_player'] == target_player.my_id:
+				if number == null or event['number'] == number:
+					pass_test("Found event %s" % event_type)
+					return
+	fail_test("Event not found: %s" % event_type)
+
+func validate_not_has_event(events, event_type, target_player, number = null):
+	for event in events:
+		if event['event_type'] == event_type:
+			if event['event_player'] == target_player.my_id:
+				if number == null or event['number'] == number:
+					fail_test("Event found: %s" % event_type)
+					return
+
+func before_each():
+	default_game_setup()
+
+	gut.p("ran setup", 2)
+
+func after_each():
+	game_logic.teardown()
+	game_logic.free()
+	gut.p("ran teardown", 2)
+
+func before_all():
+	gut.p("ran run setup", 2)
+
+func after_all():
+	gut.p("ran run teardown", 2)
+
+func do_and_validate_strike(player, card_id, ex_card_id = -1):
+	assert_true(game_logic.can_do_strike(player))
+	if card_id != -1:
+		assert_true(game_logic.do_strike(player, card_id, false, ex_card_id))
+	else:
+		var ws_card_id = player.deck[0].id
+		assert_true(game_logic.do_strike(player, card_id, true, ex_card_id))
+		card_id = ws_card_id
+
+	if game_logic.game_state == Enums.GameState.GameState_Strike_Opponent_Response or \
+			game_logic.game_state == Enums.GameState.GameState_PlayerDecision:
+		pass
+	else:
+		fail_test("Unexpected game state after initiating strike")
+		## TODO: Figure out if the test should terminate early here
+	return card_id
+
+func do_strike_response(player, card_id, ex_card_id = -1):
+	if card_id != -1:
+		assert_true(game_logic.do_strike(player, card_id, false, ex_card_id))
+	else:
+		var ws_card_id = player.deck[0].id
+		assert_true(game_logic.do_strike(player, card_id, true, ex_card_id))
+		card_id = ws_card_id
+
+	return card_id
+
+func advance_turn(player):
+	assert_true(game_logic.do_prepare(player))
+	if player.hand.size() > 7:
+		var cards = []
+		var to_discard = player.hand.size() - 7
+		for i in range(to_discard):
+			cards.append(player.hand[i].id)
+		assert_true(game_logic.do_discard_to_max(player, cards))
+
+func validate_gauge(player, amount, id):
+	assert_eq(len(player.gauge), amount)
+	if amount == 0 or len(player.gauge) != amount:
+		return
+	assert_true(
+		player.gauge.any(func (card): return card.id == id),
+		"Didn't find card %s in gauge." % id)
+
+func validate_discard(player, amount, id):
+	assert_eq(len(player.discards), amount)
+	if amount == 0 or len(player.discards) != amount:
+		return
+	assert_true(
+		player.discard.any(func (card): return card.id == id),
+		"Didn't find card %s in discard." % id)
+
+func process_decisions(player, strike_state, decisions):
+	while game_logic.game_state == Enums.GameState.GameState_PlayerDecision and \
+			game_logic.active_strike.strike_state == strike_state and \
+			game_logic.decision_info.player == player.my_id:
+		var content = decisions.pop_front()
+		if content == null:
+			fail_test("Player %s needed to decide on %s during %s but wasn't told how to" % [
+					player.my_id, Enums.DecisionType.keys()[game_logic.decision_info.type],
+					LocalGame.StrikeState.keys()[strike_state]])
+			return
+		match game_logic.decision_info.type:
+			Enums.DecisionType.DecisionType_ForceForEffect:
+				assert_true(game_logic.do_force_for_effect(player, content, false),
+						"%s failed to perform a Force effect using %s" % [player, content])
+			Enums.DecisionType.DecisionType_GaugeForEffect:
+				assert_true(game_logic.do_gauge_for_effect(player, content),
+						"%s failed to perform a Gauge effect using %s" % [player, content])
+			Enums.DecisionType.DecisionType_PayStrikeCost_Required, Enums.DecisionType.DecisionType_PayStrikeCost_CanWild:
+				# There is sometimes an init_extra_cost here
+				# TODO: See if anyone needs it to be more than 0
+				assert_true(game_logic.do_pay_strike_cost(player, content, false),
+						"%s failed to pay a Strike cost using %s" % [player, content])
+			var decision_type:  # Unknown decision type, just roll with it
+				assert_true(game_logic.do_choice(player, content),
+						"Decision of type %s unhandled by test harness (attempted by player %s, content %s)" % [
+								decision_type, player, content])
+
+func process_remaining_decisions(initiator, defender, init_choices, def_choices):
+	var empty_loop_count = 0
+	while init_choices.size() + def_choices.size() >= 1:
+		# empty_loop_count is used to detect when there are still prescribed choices in
+		# the input, but the game is not actually making additional decision points available.
+		empty_loop_count += 1
+		if empty_loop_count >= 3:
+			fail_test("Game is not providing decision points to process initiator" +
+					" choices %s or defender choices %s" % [init_choices, def_choices])
+			return
+		while game_logic.game_state == Enums.GameState.GameState_PlayerDecision:
+				## TODO: Figure out if it's really necessary to limit ourselves to this decision type
+				# and game_logic.decision_info.type == Enums.DecisionType.DecisionType_ChooseSimultaneousEffect:
+			empty_loop_count = 0  # reset the count each time we actually get into this loop; it is not empty
+			var decision = game_logic.decision_info
+			var player = initiator
+			var player_choices = init_choices
+			if decision.player == defender.my_id:
+				player = defender
+				player_choices = def_choices
+			var choice = player_choices.pop_front()
+			if choice == null:
+				fail_test("Insufficient decisions defined for player %s during strike" % player.my_id)
+				return
+			match game_logic.decision_info.type:
+				Enums.DecisionType.DecisionType_ChooseSimultaneousEffect:
+					assert_true(game_logic.do_choice(player, choice),
+							"%s failed to perform a choice with value %s" % [player, choice])
+				Enums.DecisionType.DecisionType_ChooseToDiscard:
+					assert_true(game_logic.do_choose_to_discard(player, choice),
+							"%s failed to discard cards %s" % [player, choice])
+				Enums.DecisionType.DecisionType_ForceForArmor:
+					assert_true(game_logic.do_force_for_armor(player, choice),
+							"%s failed to discard cards %s for armor" % [player, choice])
+				var decision_type:  # Unknown decision type, just roll with it?
+					if typeof(choice) == Variant.Type.TYPE_ARRAY:
+						fail_test("Attempting to apply array choice %s to a decision of type %s" % [
+								choice, Enums.DecisionType.keys()[decision_type]])
+						return
+					assert_true(game_logic.do_choice(player, choice),
+							"Decision of type %s unhandled by test harness (attempted by player %s, content %s)" % [
+									decision_type, player, choice])
+		## TODO: Does the loop need to wait a tick or two here for the game engine to
+		##     present another decision?
+		# wait_seconds(0.01)
+	if game_logic.game_state == Enums.GameState.GameState_PlayerDecision:
+		fail_test("Insufficient decisions defined for player %s during strike" % game_logic.decision_info.player)
+		return
+
+func execute_strike(initiator, defender, init_card: String, def_card: String,
+		init_ex = false, def_ex = false, init_choices = [], def_choices = []):
+	var init_card_id = -1
+	var init_card_ex_id = -1
+	var def_card_id = -1
+	var def_card_ex_id = -1
+	## TODO: Because all the card IDs are generated internally and at runtime, it is hard
+	##   to pass those IDs in through *_choices
+	if init_card:
+		init_card_id = give_player_specific_card(initiator, init_card)
+		if init_ex:
+			init_card_ex_id = give_player_specific_card(initiator, init_card)
+		do_and_validate_strike(initiator, init_card_id, init_card_ex_id)
+	else:
+		init_card_id = do_and_validate_strike(initiator, -1)  # wild swing
+	## TODO: Why no all_events modification in the initiator block? Is it
+	## because `validate` handles the only part we care about?
+	process_decisions(initiator, game_logic.StrikeState.StrikeState_Initiator_SetEffects, init_choices)
+
+	if def_card:
+		def_card_id = give_player_specific_card(defender, def_card)
+		if def_ex:
+			def_card_ex_id = give_player_specific_card(defender, def_card)
+		do_strike_response(defender, def_card_id, def_card_ex_id)
+	else:
+		def_card_id = do_strike_response(defender, -1)  # wild swing
+	process_decisions(defender, game_logic.StrikeState.StrikeState_Defender_SetEffects, def_choices)
+
+	process_decisions(initiator, game_logic.StrikeState.StrikeState_Initiator_PayCosts, init_choices)
+	process_decisions(defender, game_logic.StrikeState.StrikeState_Defender_PayCosts, def_choices)
+
+	process_remaining_decisions(initiator, defender, init_choices, def_choices)
+
+	return [init_card_id, def_card_id, init_card_ex_id, def_card_ex_id]
+
+
+func validate_positions(p1, l1, p2, l2):
+	assert_eq(p1.arena_location, l1)
+	assert_eq(p2.arena_location, l2)
+
+func validate_life(p1, l1, p2, l2):
+	assert_eq(p1.life, l1)
+	assert_eq(p2.life, l2)
+
+func get_cards_from_hand(player : LocalGame.Player, amount : int):
+	var card_ids = []
+	for i in range(amount):
+		card_ids.append(player.hand[i].id)
+	return card_ids
+
+func get_cards_from_gauge(player : LocalGame.Player, amount : int):
+	var card_ids = []
+	for i in range(amount):
+		card_ids.append(player.gauge[i].id)
+	return card_ids

--- a/test/unit/test_yuzu.gd
+++ b/test/unit/test_yuzu.gd
@@ -1,204 +1,10 @@
-extends GutTest
+extends ExceedGutTest
 
-const LocalGame = preload("res://scenes/game/local_game.gd")
-const GameCard = preload("res://scenes/game/game_card.gd")
-const Enums = preload("res://scenes/game/enums.gd")
-var game_logic : LocalGame
-var default_deck = CardDefinitions.get_deck_from_str_id("yuzu")
-const TestCardId1 = 50001
-const TestCardId2 = 50002
-const TestCardId3 = 50003
-const TestCardId4 = 50004
-const TestCardId5 = 50005
+func who_am_i():
+	return "yuzu"
 
-var player1 : LocalGame.Player
-var player2 : LocalGame.Player
-
-func default_game_setup():
-	game_logic = LocalGame.new()
-	var seed_value = randi()
-	game_logic.initialize_game(default_deck, default_deck, "p1", "p2", Enums.PlayerId.PlayerId_Player, seed_value)
-	game_logic.draw_starting_hands_and_begin()
-	game_logic.do_mulligan(game_logic.player, [])
-	game_logic.do_mulligan(game_logic.opponent, [])
-	player1 = game_logic.player
-	player2 = game_logic.opponent
-	game_logic.get_latest_events()
-
-func give_player_specific_card(player, def_id, card_id):
-	var card_def = CardDefinitions.get_card(def_id)
-	var card = GameCard.new(card_id, card_def, "image", player.my_id)
-	var card_db = game_logic.get_card_database()
-	card_db._test_insert_card(card)
-	player.hand.append(card)
-
-func give_specific_cards(p1, id1, p2, id2):
-	if p1:
-		give_player_specific_card(p1, id1, TestCardId1)
-	if p2:
-		give_player_specific_card(p2, id2, TestCardId2)
-
-func position_players(p1, loc1, p2, loc2):
-	p1.arena_location = loc1
-	p2.arena_location = loc2
-
-func give_gauge(player, amount):
-	for i in range(amount):
-		player.add_to_gauge(player.deck[0])
-		player.deck.remove_at(0)
-
-func validate_has_event(events, event_type, target_player, number = null):
-	for event in events:
-		if event['event_type'] == event_type:
-			if event['event_player'] == target_player.my_id:
-				if number != null and event['number'] == number:
-					return
-				elif number == null:
-					return
-	fail_test("Event not found: %s" % event_type)
-
-func before_each():
-	default_game_setup()
-
-	gut.p("ran setup", 2)
-
-func after_each():
-	game_logic.teardown()
-	game_logic.free()
-	gut.p("ran teardown", 2)
-
-func before_all():
-	gut.p("ran run setup", 2)
-
-func after_all():
-	gut.p("ran run teardown", 2)
-
-func do_and_validate_strike(player, card_id, ex_card_id = -1):
-	assert_true(game_logic.can_do_strike(player))
-	assert_true(game_logic.do_strike(player, card_id, false, ex_card_id))
-	var events = game_logic.get_latest_events()
-	validate_has_event(events, Enums.EventType.EventType_Strike_Started, player, card_id)
-	if game_logic.game_state == Enums.GameState.GameState_Strike_Opponent_Response or game_logic.game_state == Enums.GameState.GameState_PlayerDecision:
-		pass
-	else:
-		fail_test("Unexpected game state after strike")
-
-func do_strike_response(player, card_id, ex_card = -1):
-	assert_true(game_logic.do_strike(player, card_id, false, ex_card))
-	var events = game_logic.get_latest_events()
-	return events
-
-func advance_turn(player):
-	assert_true(game_logic.do_prepare(player))
-	if player.hand.size() > 7:
-		var cards = []
-		var to_discard = player.hand.size() - 7
-		for i in range(to_discard):
-			cards.append(player.hand[i].id)
-		assert_true(game_logic.do_discard_to_max(player, cards))
-
-func validate_gauge(player, amount, id):
-	assert_eq(len(player.gauge), amount)
-	if len(player.gauge) != amount: return
-	if amount == 0: return
-	for card in player.gauge:
-		if card.id == id:
-			return
-	fail_test("Didn't have required card in gauge.")
-
-func validate_discard(player, amount, id):
-	assert_eq(len(player.discards), amount)
-	if len(player.discards) != amount: return
-	if amount == 0: return
-	for card in player.discards:
-		if card.id == id:
-			return
-	fail_test("Didn't have required card in discard.")
-
-func handle_simultaneous_effects(initiator, defender):
-	while game_logic.game_state == Enums.GameState.GameState_PlayerDecision and game_logic.decision_info.type == Enums.DecisionType.DecisionType_ChooseSimultaneousEffect:
-		var decider = initiator
-		if game_logic.decision_info.player == defender.my_id:
-			decider = defender
-		assert_true(game_logic.do_choice(decider, 0), "Failed simuleffect choice")
-
-func execute_strike(initiator, defender, init_card : String, def_card : String, init_choices, def_choices, init_ex = false, def_ex = false, init_force_discard = [], def_force_discard = [], init_extra_cost = 0):
-	var all_events = []
-	give_specific_cards(initiator, init_card, defender, def_card)
-	if init_ex:
-		give_player_specific_card(initiator, init_card, TestCardId3)
-		do_and_validate_strike(initiator, TestCardId1, TestCardId3)
-	else:
-		do_and_validate_strike(initiator, TestCardId1)
-
-	if game_logic.game_state == Enums.GameState.GameState_PlayerDecision and game_logic.active_strike.strike_state == game_logic.StrikeState.StrikeState_Initiator_SetEffects:
-		game_logic.do_force_for_effect(initiator, init_force_discard, false)
-
-	if def_ex:
-		give_player_specific_card(defender, def_card, TestCardId4)
-		all_events += do_strike_response(defender, TestCardId2, TestCardId4)
-	elif def_card:
-		all_events += do_strike_response(defender, TestCardId2)
-
-	if game_logic.game_state == Enums.GameState.GameState_PlayerDecision and game_logic.active_strike.strike_state == game_logic.StrikeState.StrikeState_Defender_SetEffects:
-		game_logic.do_force_for_effect(defender, def_force_discard, false)
-
-	# Pay any costs from gauge
-	if game_logic.active_strike and game_logic.active_strike.strike_state == game_logic.StrikeState.StrikeState_Initiator_PayCosts:
-		var cost = game_logic.active_strike.initiator_card.definition['gauge_cost'] + init_extra_cost
-		var cards = []
-		for i in range(cost):
-			cards.append(initiator.gauge[i].id)
-		game_logic.do_pay_strike_cost(initiator, cards, false)
-
-	# Pay any costs from gauge
-	if game_logic.active_strike and game_logic.active_strike.strike_state == game_logic.StrikeState.StrikeState_Defender_PayCosts:
-		var cost = game_logic.active_strike.defender_card.definition['gauge_cost']
-		var cards = []
-		for i in range(cost):
-			cards.append(defender.gauge[i].id)
-		game_logic.do_pay_strike_cost(defender, cards, false)
-
-	handle_simultaneous_effects(initiator, defender)
-
-	for i in range(init_choices.size()):
-		assert_eq(game_logic.game_state, Enums.GameState.GameState_PlayerDecision, "not in decision for choice 1")
-		assert_true(game_logic.do_choice(initiator, init_choices[i]), "choice 1 failed")
-		handle_simultaneous_effects(initiator, defender)
-	handle_simultaneous_effects(initiator, defender)
-
-	for i in range(def_choices.size()):
-		assert_eq(game_logic.game_state, Enums.GameState.GameState_PlayerDecision, "not in decision for choice 2")
-		assert_true(game_logic.do_choice(defender, def_choices[i]), "choice 2 failed")
-		handle_simultaneous_effects(initiator, defender)
-
-	var events = game_logic.get_latest_events()
-	all_events += events
-	return all_events
-
-func validate_positions(p1, l1, p2, l2):
-	assert_eq(p1.arena_location, l1)
-	assert_eq(p2.arena_location, l2)
-
-func validate_life(p1, l1, p2, l2):
-	assert_eq(p1.life, l1)
-	assert_eq(p2.life, l2)
-
-func get_cards_from_hand(player : LocalGame.Player, amount : int):
-	var card_ids = []
-	for i in range(amount):
-		card_ids.append(player.hand[i].id)
-	return card_ids
-
-func get_cards_from_gauge(player : LocalGame.Player, amount : int):
-	var card_ids = []
-	for i in range(amount):
-		card_ids.append(player.gauge[i].id)
-	return card_ids
-
-##
-## Tests start here
-##
+## Character action: Add a card from your hand to your Gauge. If you have 4+ cards in
+##     your Gauge after this, Exceed (at no cost).
 
 func test_yuzu_ua_under_four_gauge():
 	position_players(player1, 3, player2, 5)
@@ -232,43 +38,59 @@ func test_yuzu_ua_four_gauge():
 		fail_test("Should have exceeded after character action")
 	pass_test("test passed")
 
+## Exceed mode passive: Your attacks have "Cleanup: Discard your attack."
+
 func test_yuzu_discard_block_while_exceeded():
 	position_players(player1, 3, player2, 5)
-	give_gauge(player1, 1)
-	assert_true(game_logic.do_exceed(player1, [player1.gauge[0].id]))
+	var p1_gauge = give_gauge(player1, 1)
+	assert_true(game_logic.do_exceed(player1, p1_gauge))
 
-	var events = execute_strike(player2, player1, "uni_normal_assault", "uni_normal_block", [], [], false, false)
+	var strike_cards = execute_strike(player2, player1, "uni_normal_assault", "uni_normal_block",
+		false, false, [], [[]])  # player 1 declines to pay force for block
+	var events = game_logic.get_latest_events()
 	validate_has_event(events, Enums.EventType.EventType_Strike_ForceForArmor, player1)
-	assert_eq(game_logic.game_state, Enums.GameState.GameState_PlayerDecision)
-	assert_true(game_logic.do_force_for_armor(player1, []))
 
-	events = game_logic.get_latest_events()
-	assert_true(player1.is_card_in_discards(TestCardId2))
-	assert_true(player2.is_card_in_gauge(TestCardId1))
+	assert_true(player2.is_card_in_gauge(strike_cards[0]))
+	assert_true(player1.is_card_in_discards(strike_cards[1]))
 	validate_positions(player1, 3, player2, 4)
 	validate_life(player1, 28, player2, 30)
 
+## Inochi Kurenai Cleanup: If you were stunned, you may add this card to your
+## boost area as a continuous boost and sustain it.
+
 func test_yuzu_kurenai_stunned_while_exceeded():
+	# Should be able to stack the two cleanup triggers advantageously.
 	position_players(player1, 3, player2, 5)
-	give_gauge(player1, 2)
-	assert_true(game_logic.do_exceed(player1, [player1.gauge[0].id]))
+	var p1_gauge = give_gauge(player1, 2)
+	assert_true(game_logic.do_exceed(player1, [p1_gauge[0]]))
 
-	execute_strike(player2, player1, "uni_normal_assault", "yuzu_kurenai", [], [0], false, false)
+	var strike_cards = execute_strike(player2, player1, "uni_normal_assault", "yuzu_kurenai",
+			false, false, [],
+			[[p1_gauge[1]], 1, 0]  # Pay gauge with remaining card;
+								   # then choose to discard the strike first (effect ordering);
+								   # then choose to add it to the boost area and sustain it
+		)
 
-	assert_true(player1.is_card_in_continuous_boosts(TestCardId2))
-	assert_true(player2.is_card_in_gauge(TestCardId1))
+	assert_true(player2.is_card_in_gauge(strike_cards[0]))
+	assert_true(player1.is_card_in_continuous_boosts(strike_cards[1]))
 	validate_positions(player1, 3, player2, 4)
 	validate_life(player1, 26, player2, 30)
 
+## Exceed character action: Strike with a random card from your Gauge face-up.
+##     If you did, your attack has +2 Power and +1 Speed. The opponent sets
+##     their attack first.
+
 func test_yuzu_strike_from_gauge_assault():
 	position_players(player1, 3, player2, 5)
-	give_player_specific_card(player1, "uni_normal_assault", TestCardId3)
-	player1.move_card_from_hand_to_gauge(TestCardId3)
+	var assault_id = give_player_specific_card(player1, "uni_normal_assault")
+	player1.move_card_from_hand_to_gauge(assault_id)
 	player1.exceed()
+	# Expected: Yuzuriha uses her character action to set Assault from her gauge.
+	#     It has speed 5 + 1 and hits for 4 + 2 and wins a speed tie against Cross.
 	assert_true(game_logic.do_character_action(player1, [], 0))
 	assert_true(game_logic.do_strike(player1, -1, false, -1, true))
-	give_player_specific_card(player2, "uni_normal_cross", TestCardId4)
-	assert_true(game_logic.do_strike(player2, TestCardId4, false, -1, true))
+	var cross_id = give_player_specific_card(player2, "uni_normal_cross")
+	assert_true(game_logic.do_strike(player2, cross_id, false, -1, true))
 	validate_life(player1, 30, player2, 24)
 	validate_positions(player1, 4, player2, 5)
 	assert_eq(game_logic.active_turn_player, player1.my_id)

--- a/test/unit/test_zangief.gd
+++ b/test/unit/test_zangief.gd
@@ -1,202 +1,7 @@
-extends GutTest
+extends ExceedGutTest
 
-const LocalGame = preload("res://scenes/game/local_game.gd")
-const GameCard = preload("res://scenes/game/game_card.gd")
-const Enums = preload("res://scenes/game/enums.gd")
-var game_logic : LocalGame
-var default_deck = CardDefinitions.get_deck_from_str_id("zangief")
-const TestCardId1 = 50001
-const TestCardId2 = 50002
-const TestCardId3 = 50003
-const TestCardId4 = 50004
-const TestCardId5 = 50005
-
-var player1 : LocalGame.Player
-var player2 : LocalGame.Player
-
-func default_game_setup(alt_opponent : String = ""):
-	var opponent_deck = default_deck
-	if alt_opponent:
-		opponent_deck = CardDefinitions.get_deck_from_str_id(alt_opponent)
-	game_logic = LocalGame.new()
-	var seed_value = randi()
-	game_logic.initialize_game(default_deck, opponent_deck, "p1", "p2", Enums.PlayerId.PlayerId_Player, seed_value)
-	game_logic.draw_starting_hands_and_begin()
-	game_logic.do_mulligan(game_logic.player, [])
-	game_logic.do_mulligan(game_logic.opponent, [])
-	player1 = game_logic.player
-	player2 = game_logic.opponent
-	game_logic.get_latest_events()
-
-func give_player_specific_card(player, def_id, card_id):
-	var card_def = CardDefinitions.get_card(def_id)
-	var card = GameCard.new(card_id, card_def, "image", player.my_id)
-	var card_db = game_logic.get_card_database()
-	card_db._test_insert_card(card)
-	player.hand.append(card)
-
-func give_specific_cards(p1, id1, p2, id2):
-	if p1:
-		give_player_specific_card(p1, id1, TestCardId1)
-	if p2:
-		give_player_specific_card(p2, id2, TestCardId2)
-
-func position_players(p1, loc1, p2, loc2):
-	p1.arena_location = loc1
-	p2.arena_location = loc2
-
-func give_gauge(player, amount):
-	for i in range(amount):
-		player.add_to_gauge(player.deck[0])
-		player.deck.remove_at(0)
-
-func validate_has_event(events, event_type, target_player, number = null):
-	for event in events:
-		if event['event_type'] == event_type:
-			if event['event_player'] == target_player.my_id:
-				if number != null and event['number'] == number:
-					return
-				elif number == null:
-					return
-	fail_test("Event not found: %s" % event_type)
-
-func before_each():
-	default_game_setup()
-
-	gut.p("ran setup", 2)
-
-func after_each():
-	game_logic.teardown()
-	game_logic.free()
-	gut.p("ran teardown", 2)
-
-func before_all():
-	gut.p("ran run setup", 2)
-
-func after_all():
-	gut.p("ran run teardown", 2)
-
-func do_and_validate_strike(player, card_id, ex_card_id = -1):
-	assert_true(game_logic.can_do_strike(player))
-	assert_true(game_logic.do_strike(player, card_id, false, ex_card_id))
-	var events = game_logic.get_latest_events()
-	validate_has_event(events, Enums.EventType.EventType_Strike_Started, player, card_id)
-	if game_logic.game_state == Enums.GameState.GameState_Strike_Opponent_Response or game_logic.game_state == Enums.GameState.GameState_PlayerDecision:
-		pass
-	else:
-		fail_test("Unexpected game state after strike")
-
-func do_strike_response(player, card_id, ex_card = -1):
-	assert_true(game_logic.do_strike(player, card_id, false, ex_card))
-	var events = game_logic.get_latest_events()
-	return events
-
-func advance_turn(player):
-	assert_true(game_logic.do_prepare(player))
-	if player.hand.size() > 7:
-		var cards = []
-		var to_discard = player.hand.size() - 7
-		for i in range(to_discard):
-			cards.append(player.hand[i].id)
-		assert_true(game_logic.do_discard_to_max(player, cards))
-
-func validate_gauge(player, amount, id):
-	assert_eq(len(player.gauge), amount)
-	if len(player.gauge) != amount: return
-	if amount == 0: return
-	for card in player.gauge:
-		if card.id == id:
-			return
-	fail_test("Didn't have required card in gauge.")
-
-func validate_discard(player, amount, id):
-	assert_eq(len(player.discards), amount)
-	if len(player.discards) != amount: return
-	if amount == 0: return
-	for card in player.discards:
-		if card.id == id:
-			return
-	fail_test("Didn't have required card in discard.")
-
-func handle_simultaneous_effects(initiator, defender):
-	while game_logic.game_state == Enums.GameState.GameState_PlayerDecision and game_logic.decision_info.type == Enums.DecisionType.DecisionType_ChooseSimultaneousEffect:
-		var decider = initiator
-		if game_logic.decision_info.player == defender.my_id:
-			decider = defender
-		assert_true(game_logic.do_choice(decider, 0), "Failed simuleffect choice")
-
-func execute_strike(initiator, defender, init_card : String, def_card : String, init_choices, def_choices,
-		init_ex = false, def_ex = false, init_force_discard = [], def_force_discard = [], init_extra_cost = 0, init_set_effect_gauge = false, def_set_effect_gauge = false):
-	var all_events = []
-	give_specific_cards(initiator, init_card, defender, def_card)
-	if init_ex:
-		give_player_specific_card(initiator, init_card, TestCardId3)
-		do_and_validate_strike(initiator, TestCardId1, TestCardId3)
-	else:
-		do_and_validate_strike(initiator, TestCardId1)
-
-	if game_logic.game_state == Enums.GameState.GameState_PlayerDecision and game_logic.active_strike.strike_state == game_logic.StrikeState.StrikeState_Initiator_SetEffects:
-		if init_set_effect_gauge:
-			assert_true(game_logic.do_gauge_for_effect(initiator, init_force_discard), "failed do_gauge_for_effect")
-		else:
-			assert_true(game_logic.do_force_for_effect(initiator, init_force_discard, false), "failed do_force_for_effect")
-
-	if def_ex:
-		give_player_specific_card(defender, def_card, TestCardId4)
-		all_events += do_strike_response(defender, TestCardId2, TestCardId4)
-	elif def_card:
-		all_events += do_strike_response(defender, TestCardId2)
-
-	if game_logic.game_state == Enums.GameState.GameState_PlayerDecision and game_logic.active_strike.strike_state == game_logic.StrikeState.StrikeState_Defender_SetEffects:
-		if def_set_effect_gauge:
-			assert_true(game_logic.do_gauge_for_effect(defender, def_force_discard), "failed defender do_gauge_for_effect")
-		else:
-			assert_true(game_logic.do_force_for_effect(defender, def_force_discard, false), "failed defender do_force_for_effect")
-
-	# Pay any costs from gauge
-	if game_logic.active_strike and game_logic.active_strike.strike_state == game_logic.StrikeState.StrikeState_Initiator_PayCosts:
-		var cost = game_logic.active_strike.initiator_card.definition['gauge_cost'] + init_extra_cost
-		var cards = []
-		for i in range(cost):
-			cards.append(initiator.gauge[i].id)
-		game_logic.do_pay_strike_cost(initiator, cards, false)
-
-	# Pay any costs from gauge
-	if game_logic.active_strike and game_logic.active_strike.strike_state == game_logic.StrikeState.StrikeState_Defender_PayCosts:
-		var cost = game_logic.active_strike.defender_card.definition['gauge_cost']
-		var cards = []
-		for i in range(cost):
-			cards.append(defender.gauge[i].id)
-		game_logic.do_pay_strike_cost(defender, cards, false)
-
-	handle_simultaneous_effects(initiator, defender)
-
-	for i in range(init_choices.size()):
-		assert_eq(game_logic.game_state, Enums.GameState.GameState_PlayerDecision)
-		assert_true(game_logic.do_choice(initiator, init_choices[i]))
-		handle_simultaneous_effects(initiator, defender)
-	handle_simultaneous_effects(initiator, defender)
-
-	for i in range(def_choices.size()):
-		assert_eq(game_logic.game_state, Enums.GameState.GameState_PlayerDecision)
-		assert_true(game_logic.do_choice(defender, def_choices[i]))
-		handle_simultaneous_effects(initiator, defender)
-
-	var events = game_logic.get_latest_events()
-	all_events += events
-	return all_events
-
-func validate_positions(p1, l1, p2, l2):
-	assert_eq(p1.arena_location, l1)
-	assert_eq(p2.arena_location, l2)
-
-func validate_life(p1, l1, p2, l2):
-	assert_eq(p1.life, l1)
-	assert_eq(p2.life, l2)
-
-##
-## Tests start here
-##
+func who_am_i():
+	return "zangief"
 
 # UA
 # Exceed and UA
@@ -204,38 +9,37 @@ func validate_life(p1, l1, p2, l2):
 
 func test_zangief_crit_power():
 	position_players(player1, 6, player2, 7)
-	give_gauge(player1, 1)
-	give_gauge(player2, 2)
-	give_player_specific_card(player1, "zangief_flyingpowerbomb", TestCardId1)
-	give_player_specific_card(player2, "zangief_atomicsuplex", TestCardId2)
-	assert_true(game_logic.do_strike(player1, TestCardId1, false, -1))
-	assert_true(game_logic.do_gauge_for_effect(player1, [player1.gauge[0].id]))
-	assert_true(game_logic.do_strike(player2, TestCardId2, false, -1))
-	assert_true(game_logic.do_gauge_for_effect(player2, [player2.gauge[0].id]))
+	var p1_gauge = give_gauge(player1, 1)
+	var p2_gauge = give_gauge(player2, 2)
+	execute_strike(player1, player2, "zangief_flyingpowerbomb", "zangief_atomicsuplex",
+			false, false, [p1_gauge], [[p2_gauge[0]]])
+	# Expected: Atomic Suplex swings for 4 + 1 (crit), push 3, close 3 (crit)
+	#           Flying Power Bomb swings (crit stun immune) for 6 + 1 (crit)
 	validate_positions(player1, 3, player2, 4)
 	validate_life(player1, 25, player2, 23)
 
 func test_zangief_exceed_crit():
 	position_players(player1, 4, player2, 7)
-	give_gauge(player1, 4)
-	var card_ids = player1.get_card_ids_in_gauge().slice(1)
-	assert_true(game_logic.do_exceed(player1, card_ids))
-	assert_true(game_logic.do_choice(player1, 1))
+	var p1_gauge = give_gauge(player1, 4)
+	assert_true(game_logic.do_exceed(player1, p1_gauge.slice(1)))
+	assert_true(game_logic.do_choice(player1, 1))  # When you Exceed, pull up to 2
 	validate_positions(player1, 4, player2, 5)
 	# P2 turn
-	give_player_specific_card(player1, "zangief_atomicsuplex", TestCardId1)
-	give_player_specific_card(player2, "standard_normal_cross", TestCardId2)
-	assert_true(game_logic.do_strike(player2, TestCardId2, false, -1))
-	assert_true(game_logic.do_strike(player1, TestCardId1, false, -1))
-	assert_true(game_logic.do_gauge_for_effect(player1, [player1.gauge[0].id]))
+	execute_strike(player2, player1, "standard_normal_cross", "zangief_atomicsuplex", 
+			false, false, [], [[p1_gauge[0]]])
+	# Expected: Atomic Suplex outspeeds Cross (6 + 1 (crit)), hits for 4 + 3 (crit), push 3, close 3 (crit)
 	validate_positions(player1, 7, player2, 8)
 	validate_life(player1, 30, player2, 23)
-	advance_turn(player1)
+
+## Tests of Flying Power Bomb's boost:
+##   Name a range; the opponent must discard a card that includes that range or reveal a hand that
+##   doesn't contain such a card.
+## (Reminder: All test setups are mirror matches.)
 
 func test_zangief_flyingpowerbomb_boost_reveal():
 	position_players(player1, 4, player2, 7)
-	give_player_specific_card(player1, "zangief_flyingpowerbomb", TestCardId1)
-	assert_true(game_logic.do_boost(player1, TestCardId1))
+	var card_id = give_player_specific_card(player1, "zangief_flyingpowerbomb")
+	assert_true(game_logic.do_boost(player1, card_id))
 
 	# Name the range 0-8 are real ranges, 9 is a valid choice but doesn't exist, 10 is X, 11 is -
 	assert_true(game_logic.do_choice(player1, 10)) # Zangief has no X cards.
@@ -245,8 +49,8 @@ func test_zangief_flyingpowerbomb_boost_reveal():
 
 func test_zangief_flyingpowerbomb_boost_reveal2():
 	position_players(player1, 4, player2, 7)
-	give_player_specific_card(player1, "zangief_flyingpowerbomb", TestCardId1)
-	assert_true(game_logic.do_boost(player1, TestCardId1))
+	var card_id = give_player_specific_card(player1, "zangief_flyingpowerbomb")
+	assert_true(game_logic.do_boost(player1, card_id))
 
 	# Name the range 0-8 are real ranges, 9 is a valid choice but doesn't exist, 10 is X, 11 is -
 	assert_true(game_logic.do_choice(player1, 4)) # Zangief has no 4
@@ -256,51 +60,53 @@ func test_zangief_flyingpowerbomb_boost_reveal2():
 
 func test_zangief_flyingpowerbomb_boost_discard_block():
 	position_players(player1, 4, player2, 7)
-	give_player_specific_card(player1, "zangief_flyingpowerbomb", TestCardId1)
-	assert_true(game_logic.do_boost(player1, TestCardId1))
+	var power_bomb_id = give_player_specific_card(player1, "zangief_flyingpowerbomb")
+	assert_true(game_logic.do_boost(player1, power_bomb_id))
 	player2.discard_hand()
-	give_player_specific_card(player2, "standard_normal_block", TestCardId2)
+	var block_id = give_player_specific_card(player2, "standard_normal_block")
 	# Name the range 0-8 are real ranges, 9 is a valid choice but doesn't exist, 10 is X, 11 is -
 	assert_true(game_logic.do_choice(player1, 11))
-	assert_true(game_logic.do_choose_to_discard(player2, [TestCardId2]))
+	assert_true(game_logic.do_choose_to_discard(player2, [block_id]))
 	advance_turn(player2)
 
 func test_zangief_flyingpowerbomb_boost_discard_X():
 	position_players(player1, 4, player2, 7)
-	give_player_specific_card(player1, "zangief_flyingpowerbomb", TestCardId1)
-	assert_true(game_logic.do_boost(player1, TestCardId1))
+	var power_bomb_id = give_player_specific_card(player1, "zangief_flyingpowerbomb")
+	assert_true(game_logic.do_boost(player1, power_bomb_id))
 	player2.discard_hand()
-	give_player_specific_card(player2, "phonon_impulsivefrustration", TestCardId2)
-	# Name the range 0-8 are real ranges, 9 is a valid choice but doesn't exist, 10 is X, 11 is -
+	var frustration_id = give_player_specific_card(player2, "phonon_impulsivefrustration")
+	# Range 2~X; Zangief calls "X" as the range
 	assert_true(game_logic.do_choice(player1, 10))
-	assert_true(game_logic.do_choose_to_discard(player2, [TestCardId2]))
+	assert_true(game_logic.do_choose_to_discard(player2, [frustration_id]))
 	advance_turn(player2)
 
 func test_zangief_flyingpowerbomb_boost_discard_3_with_X_eval():
 	position_players(player1, 4, player2, 7)
-	give_player_specific_card(player1, "zangief_flyingpowerbomb", TestCardId1)
-	assert_true(game_logic.do_boost(player1, TestCardId1))
+	var power_bomb_id = give_player_specific_card(player1, "zangief_flyingpowerbomb")
+	assert_true(game_logic.do_boost(player1, power_bomb_id))
 
 	player2.discard_hand()
-	give_player_specific_card(player2, "phonon_impulsivefrustration", TestCardId2)
-	# Name the range 0-8 are real ranges, 9 is a valid choice but doesn't exist, 10 is X, 11 is -
+	var frustration_id = give_player_specific_card(player2, "phonon_impulsivefrustration")
+	# Range 2~X where X is the attack's Power (printed 3); Zangief calls "3"
 	assert_true(game_logic.do_choice(player1, 3))
-	assert_true(game_logic.do_choose_to_discard(player2, [TestCardId2]))
+	assert_true(game_logic.do_choose_to_discard(player2, [frustration_id]))
 	advance_turn(player2)
 
 func test_zangief_flyingpowerbomb_boost_discard_4_with_X_eval_fails():
 	position_players(player1, 4, player2, 7)
 	advance_turn(player1)
-	give_player_specific_card(player2, "phonon_turningsatisfaction", TestCardId3)
-	assert_true(game_logic.do_boost(player2, TestCardId3))
+	var tuning_id = give_player_specific_card(player2, "phonon_turningsatisfaction")
+	assert_true(game_logic.do_boost(player2, tuning_id))
+	# Continuous boost: +1 Power
 	advance_turn(player2)
 	player1.discard_hand()
-	give_player_specific_card(player1, "zangief_flyingpowerbomb", TestCardId1)
-	assert_true(game_logic.do_boost(player1, TestCardId1))
+	var power_bomb_id = give_player_specific_card(player1, "zangief_flyingpowerbomb")
+	assert_true(game_logic.do_boost(player1, power_bomb_id))
 
 	player2.discard_hand()
-	give_player_specific_card(player2, "phonon_impulsivefrustration", TestCardId2)
-	# Name the range 0-8 are real ranges, 9 is a valid choice but doesn't exist, 10 is X, 11 is -
+	var frustration_id = give_player_specific_card(player2, "phonon_impulsivefrustration")
+	# Range 2~X where X is the attack's Power (printed 3)
+	# Zangief calls "4", which whiffs because the continuous boost only applies during a strike or something
 	assert_true(game_logic.do_choice(player1, 4))
 	var events = game_logic.get_latest_events()
 	validate_has_event(events, Enums.EventType.EventType_RevealHand, player2)
@@ -308,50 +114,52 @@ func test_zangief_flyingpowerbomb_boost_discard_4_with_X_eval_fails():
 
 func test_zangief_flyingpowerbomb_boost_discard_3():
 	position_players(player1, 4, player2, 7)
-	give_player_specific_card(player1, "zangief_flyingpowerbomb", TestCardId1)
-	assert_true(game_logic.do_boost(player1, TestCardId1))
+	var power_bomb_id = give_player_specific_card(player1, "zangief_flyingpowerbomb")
+	assert_true(game_logic.do_boost(player1, power_bomb_id))
 
 	player2.discard_hand()
-	give_player_specific_card(player2, "standard_normal_sweep", TestCardId2)
+	var sweep_id = give_player_specific_card(player2, "standard_normal_sweep")
 	# Name the range 0-8 are real ranges, 9 is a valid choice but doesn't exist, 10 is X, 11 is -
 	assert_true(game_logic.do_choice(player1, 3))
-	assert_true(game_logic.do_choose_to_discard(player2, [TestCardId2]))
+	assert_true(game_logic.do_choose_to_discard(player2, [sweep_id]))
 	advance_turn(player2)
 
 func test_zangief_flyingpowerbomb_boost_discard_kunzite():
 	position_players(player1, 1, player2, 3)
-	give_player_specific_card(player1, "zangief_flyingpowerbomb", TestCardId1)
-	assert_true(game_logic.do_boost(player1, TestCardId1))
+	var power_bomb_id = give_player_specific_card(player1, "zangief_flyingpowerbomb")
+	assert_true(game_logic.do_boost(player1, power_bomb_id))
 
 	player2.discard_hand()
-	give_player_specific_card(player2, "nine_kunzite", TestCardId2)
-	# Name the range 0-8 are real ranges, 9 is a valid choice but doesn't exist, 10 is X, 11 is -
-	assert_true(game_logic.do_choice(player1, 2)) # We're range 2 so kunzite should be 2
-	assert_true(game_logic.do_choose_to_discard(player2, [TestCardId2])) # If this fails, then kunzite didn't match
+	var kunzite_id = give_player_specific_card(player2, "nine_kunzite")
+	# Range X, where X is your range to the opponent
+	assert_true(game_logic.do_choice(player1, 2))
+	assert_true(game_logic.do_choose_to_discard(player2, [kunzite_id]))
 	advance_turn(player2)
+
+## Test Siberian Blizzard passive effect: Opponents can't move past you.
 
 func test_zangief_siberian_move():
 	position_players(player1, 3, player2, 6)
-	give_gauge(player1, 3)
-	give_player_specific_card(player1, "zangief_siberianblizzard", TestCardId1)
-	give_player_specific_card(player2, "standard_normal_dive", TestCardId2)
-	assert_true(game_logic.do_strike(player1, TestCardId1, false, -1))
-	assert_true(game_logic.do_gauge_for_effect(player1, [])) # Skip critical
-	assert_true(game_logic.do_strike(player2, TestCardId2, false, -1))
+	var p1_gauge = give_gauge(player1, 3)
+
 	assert_eq(player1.hand.size(), 5)
-	assert_true(game_logic.do_pay_strike_cost(player1, player1.get_card_ids_in_gauge(), false))
-	assert_eq(player1.hand.size(), 7)
+	execute_strike(player1, player2, "zangief_siberianblizzard", "standard_normal_dive",
+			false, false,
+			[[], p1_gauge],  # Pass on critical payment; pay all gauge for the Ultra
+			[])
+	assert_eq(player1.hand.size(), 7)  # Original 5 + Blizzard - Blizzard + Draw 2 on Hit
+	# Expected: Dive goes first but can't cross over; hits for 5, doesn't stun
+	#           Blizzard hits back for 8
 	validate_positions(player1, 3, player2, 4)
 	validate_life(player1, 25, player2, 22)
-	# Player 2, make sure we can move past them.
+
+	# Verify that player 2 can still cross over outside of the strike
 	assert_true(game_logic.do_move(player2, [player2.hand[0].id, player2.hand[1].id], 2))
 	validate_positions(player1, 3, player2, 2)
-	give_player_specific_card(player1, "standard_normal_sweep", TestCardId3)
-	give_player_specific_card(player2, "standard_normal_dive", TestCardId4)
-	assert_true(game_logic.do_strike(player1, TestCardId3, false, -1))
-	assert_true(game_logic.do_gauge_for_effect(player1, [])) # Skip critical
-	assert_true(game_logic.do_strike(player2, TestCardId4, false, -1))
-	assert_true(game_logic.do_gauge_for_effect(player2, [])) # Skip critical
+
+	# Verify that the movement block doesn't persist to the next strike
+	execute_strike(player1, player2, "standard_normal_sweep", "standard_normal_dive",
+			false, false, [[]], [[]])  # Empty options to decline critical
 	validate_positions(player1, 3, player2, 6)
 	validate_life(player1, 25, player2, 22)
 	advance_turn(player2)


### PR DESCRIPTION
A bunch of functions common to all the test classes, including the oft-used `execute_strike`, are moved to a parent class `ExceedGutTest` and then made available to unit test classes through inheritance. In addition, the following refactoring changes were made:

  * All player decisions are collapsed to a single array. It is up to the test author to structure this input so that its order and content types match the order and content types of the decisions that will be offered. When converting an old test, this means that some decisions will need to be specified when they didn't used to be. The original code would default to "choice 0" if you didn't say anything, but the new code will generate a failure indicating that it wants instructions. Error/failure messages are structured to hopefully provide context to make it easy to figure out where the test got confused.

    Why do it this way? While beginning to merge tests to share common behavior, I noticed that the function signature of `execute_strike` would vary based on the new needs of a character. Aside from the more common attack effect decisions, some characters need to try paying Gauge costs in particular ways, or setting attacks face up, and so on and so on. Over time, this causes the argument list of `execute_strike` to bloat, and tests start having to add a bunch of "blank" arguments (like `[]` or `0` or `false`, depending on type) in order to get to the part of the argument list it actually cares about. (This is partially a fault of gdscript itself for not supporting keyword arguments.) For a unified test suite, this is a huge maintenance burden.

    So from now on, if you want to support a *new* kind of decision, all you have to do is add it in the right place in the list. Instead of adding an argument to support new behavior, simply add a branch of the appropriate enum to one of the `match` statements in `process_decisions` or `process_remaining_decisions` in `exceed_test.gd`. Error messages are provided to help indicate when a decision type needs more support.
    
  * Test card IDs are automatically assigned by a counter that just spits out a fresh ID any time you ask for one. This lowers the risk of using a duplicate ID (in which case the game engine will complain about you trying to manipulate a component that has already been `free`d). (For example, if you needed to `execute_strike` twice in one test, the old code would try to reuse `TestCardId1` and `TestCardId2` the second time around.) You can track as many cards as you need to for any test case without having to add new `TestCardIdN` constants. You will need to assign a variable to track the id number whenever you need to use it in more than one place, but hopefully this also makes the code more readable since you can talk about `assault_id` as clearly being an Assault card instead of remembering what kind of thing `TestCardId3` points to.

    The upshot: `give_specific_cards`, `give_player_specific_card`, `give_gauge`, and `execute_strike` all return integers or lists of integers: newly generated id(s) for later use in the test. Remember to bind the return values to something when it's relevant.

    Second upshot: `do_and_validate_strike` and `execute_strike` no longer return the event queue. In order to preserve the event queue so that tests that care about it can inspect it without surprises (i.e. they get a clean and complete copy of the event queue when they ask for it), these functions now do not interact with the event queue at all, and the validation check in `do_and_validate_strike` is solely based on the game state.

  * Code that uses `fail_test` to signal a bad input value or similar also try to `return` immediately afterwards. This is because `fail_test` does not actually abort the test, so if the code continues running and encounters an error, the test runner throws an error into the **editor**... which stops test suite execution and clobbers any useful test failure messages that would have been presented upon completion.

    (Doing this in a more comprehesively correct way is stymied by the lack of proper exception handling in gdscript.)

  * Some core libraries have gained a `class_name`, which makes them accessible globally without having to `const MyLibrary = preload(...)` and allows for inheritance between script files. There is no disruption to unconverted code; it's still okay to `preload` those files into a `const` even if it won't be necessary anymore. (Downside: Every time you mess with `class_name`s, the Godot editor will insist on a project reload so it can do Magical IDE Things (tm).)

The test suites for Waldstein, Yuzuriha, and Zangief have been converted. There is no disruption to other test code; the other existing tests continue to run using the original framework and will continue to do so until they're converted to `extend ExceedGutTest`.