### PR TITLE
Re-add missing class_name declaration

### DIFF
--- a/scenes/game/enums.gd
+++ b/scenes/game/enums.gd
@@ -1,3 +1,4 @@
+class_name Enums
 extends Node
 
 enum PlayerId {


### PR DESCRIPTION
In reverting enums.gd for pull request #136 I also reverted the one line that actually mattered. Oops.