### PR TITLE
Optimizations to some AI math

### DIFF
--- a/test/unit/test_ai_eval.gd
+++ b/test/unit/test_ai_eval.gd
@@ -22,10 +22,15 @@ func after_all():
 func test_ai_validation_test():
 	var deck = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 	var cards_to_find = [3]
-	assert_eq(0.1, ai_rules._probability_of_drawing(cards_to_find, 1, deck))
-	assert_eq(0.3, ai_rules._probability_of_drawing(cards_to_find, 3, deck))
-	assert_eq(1.0, ai_rules._probability_of_drawing(cards_to_find, 10, deck))
-	print("%s" % ai_rules._probability_of_drawing([1, 2], 7, deck))
+
+	# Have to use almost_eq due to floating point imprecision
+	var EPSILON := 0.000001
+	assert_almost_eq(0.1, ai_rules._probability_of_drawing(cards_to_find, 1, deck), EPSILON)
+	assert_almost_eq(0.3, ai_rules._probability_of_drawing(cards_to_find, 3, deck), EPSILON)
+	assert_almost_eq(0.3, ai_rules._probability_of_drawing([6, 9, 4, -1], 1, deck), EPSILON)
+	assert_almost_eq(1.0, ai_rules._probability_of_drawing(cards_to_find, 10, deck), EPSILON)
+	assert_almost_eq(1.0, ai_rules._probability_of_drawing(cards_to_find, 50, deck), EPSILON)
+	assert_almost_eq(17.0 / 45.0, ai_rules._probability_of_drawing([2, 5], 2, deck), EPSILON)
 
 func helper(events : Array):
 	events.append_array([6,7])


### PR DESCRIPTION
Factorial: Cache results. O(N) space where N is the highest input you care about.

N-choose-K: Cache results. O(N^2) space where N is the highest input you care about. Also computers are way faster at addition than at division (by numbers that are not powers of 2), so we're using the Pascal's triangle recurrence to compute this.

Probability of drawing: Instead of computing the odds of exactly 1 hit + exactly 2 hits + ... + exactly K hits in K draws, we compute the odds of exactly K misses and subtract from 1.

Unit test: As a result of the above change to probability of drawing, I have to allow for some floating point imprecision in the unit tests. This isn't an issue with the new method; it's because stuff like `assert_eq(1.0 - 0.7, 0.3)` fails.