### PR TITLE
Wagner unit tests

### DIFF
--- a/scenes/game/local_game.gd
+++ b/scenes/game/local_game.gd
@@ -4212,8 +4212,7 @@ func handle_strike_effect(card_id : int, effect, performing_player : Player):
 				performing_player.strike_stat_boosts.added_attack_effects.append(effect_to_add)
 		"add_boost_to_gauge_on_strike_cleanup":
 			if card_id == -1:
-				assert(false)
-				printlog("ERROR: Unimplemented path to add_boost_to_gauge_on_strike_cleanup")
+				assert(false, "ERROR: Unimplemented path to add_boost_to_gauge_on_strike_cleanup")
 			#performing_player.add_boost_to_gauge_on_strike_cleanup(card_id)
 			# Switching to doing it immediately
 			var card = card_db.get_card(card_id)

--- a/test/exceed_test.gd
+++ b/test/exceed_test.gd
@@ -95,12 +95,18 @@ func after_all():
 	gut.p("ran run teardown", 2)
 
 func do_and_validate_strike(player, card_id, ex_card_id = -1):
-	assert_true(game_logic.can_do_strike(player))
+	assert_true(game_logic.can_do_strike(player),
+			"Player %s is unable to perform a strike" % player)
 	if card_id != -1:
-		assert_true(game_logic.do_strike(player, card_id, false, ex_card_id))
+		assert_true(game_logic.do_strike(player, card_id, false, ex_card_id),
+				"Unsuccessful attempt to initiate strike with %s%s" % [
+						"EX " if ex_card_id >= 0 else "",
+						game_logic.get_card_database().get_card_name(card_id)])
 	else:
 		var ws_card_id = player.deck[0].id
-		assert_true(game_logic.do_strike(player, card_id, true, ex_card_id))
+		assert_true(game_logic.do_strike(player, card_id, true, ex_card_id),
+				"Unsuccessful attempt to initiate with wild swing (%s)" % [
+						game_logic.get_card_database().get_card_name(ws_card_id)])
 		card_id = ws_card_id
 
 	if game_logic.game_state == Enums.GameState.GameState_Strike_Opponent_Response or \
@@ -113,16 +119,21 @@ func do_and_validate_strike(player, card_id, ex_card_id = -1):
 
 func do_strike_response(player, card_id, ex_card_id = -1):
 	if card_id != -1:
-		assert_true(game_logic.do_strike(player, card_id, false, ex_card_id))
+		assert_true(game_logic.do_strike(player, card_id, false, ex_card_id),
+				"Unsuccessful attempt to initiate strike with %s%s" % [
+						"EX " if ex_card_id >= 0 else "",
+						game_logic.get_card_database().get_card_name(card_id)])
 	else:
 		var ws_card_id = player.deck[0].id
-		assert_true(game_logic.do_strike(player, card_id, true, ex_card_id))
+		assert_true(game_logic.do_strike(player, card_id, true, ex_card_id),
+				"Unsuccessful attempt to initiate with wild swing (%s)" % [
+						game_logic.get_card_database().get_card_name(ws_card_id)])
 		card_id = ws_card_id
-
 	return card_id
 
 func advance_turn(player):
-	assert_true(game_logic.do_prepare(player))
+	assert_true(game_logic.do_prepare(player),
+			"Player %s tried to prepare but could not." % (player.my_id))
 	if player.hand.size() > 7:
 		var cards = []
 		var to_discard = player.hand.size() - 7
@@ -195,7 +206,7 @@ func process_remaining_decisions(initiator, defender, init_choices, def_choices)
 				player_choices = def_choices
 			var choice = player_choices.pop_front()
 			if choice == null:
-				fail_test("Insufficient decisions defined for player %s during strike" % player.my_id)
+				fail_test("Insufficient decisions defined for player %s during strike" % (player.my_id))
 				return
 			match game_logic.decision_info.type:
 				Enums.DecisionType.DecisionType_ChooseSimultaneousEffect:


### PR DESCRIPTION
* Migrate Wagner's unit tests to ExceedGutTest and fix where relevant (some instances of `position_players` should have been `validate_positions`)
* Add ability to specify `execute_strike` cards by card ID (instead of just their string ID)
* Make certain error messages more helpful/visible