### PR TITLE
Rename do_card_from_hand_to_gauge

### DIFF
--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -1587,7 +1587,7 @@ func _on_choose_card_hand_to_gauge(event):
 	if player == Enums.PlayerId.PlayerId_Player and not observer_mode:
 		if prepared_character_action_data_available('gauge_from_hand'):
 			var selected_card_ids = prepared_character_action_data['hand_to_gauge_cards']
-			var success = game_wrapper.submit_card_from_hand_to_gauge(Enums.PlayerId.PlayerId_Player, selected_card_ids)
+			var success = game_wrapper.submit_relocate_card_from_hand(Enums.PlayerId.PlayerId_Player, selected_card_ids)
 			if success:
 				prepared_character_action_data = {}
 				change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4194,7 +4194,7 @@ func _on_instructions_ok_button_pressed(index : int):
 			UISubState.UISubState_SelectCards_ChooseBoostsToSustain:
 				success = game_wrapper.submit_choose_from_boosts(Enums.PlayerId.PlayerId_Player, selected_card_ids)
 			UISubState.UISubState_SelectCards_DiscardCardsToGauge:
-				success = game_wrapper.submit_card_from_hand_to_gauge(Enums.PlayerId.PlayerId_Player, selected_card_ids)
+				success = game_wrapper.submit_relocate_card_from_hand(Enums.PlayerId.PlayerId_Player, selected_card_ids)
 			UISubState.UISubState_SelectCards_StrikeGauge, UISubState.UISubState_SelectCards_StrikeForce:
 				success = game_wrapper.submit_pay_strike_cost(Enums.PlayerId.PlayerId_Player, selected_card_ids, false, discard_ex_first_for_strike, use_free_force)
 			UISubState.UISubState_SelectCards_Exceed:
@@ -4280,7 +4280,7 @@ func _on_instructions_cancel_button_pressed():
 		UISubState.UISubState_SelectCards_DiscardCardsToGauge:
 			deselect_all_cards()
 			close_popout()
-			success = game_wrapper.submit_card_from_hand_to_gauge(Enums.PlayerId.PlayerId_Player, [])
+			success = game_wrapper.submit_relocate_card_from_hand(Enums.PlayerId.PlayerId_Player, [])
 		UISubState.UISubState_SelectCards_ChooseBoostsToSustain:
 			deselect_all_cards()
 			close_popout()
@@ -4715,7 +4715,7 @@ func ai_choose_card_hand_to_gauge(min_amount, max_amount):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
 	var cardfromhandtogauge_action = ai_player.pick_card_hand_to_gauge(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, min_amount, max_amount)
-	var success = game_wrapper.submit_card_from_hand_to_gauge(Enums.PlayerId.PlayerId_Opponent, cardfromhandtogauge_action.card_ids)
+	var success = game_wrapper.submit_relocate_card_from_hand(Enums.PlayerId.PlayerId_Opponent, cardfromhandtogauge_action.card_ids)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
 	else:

--- a/scenes/game/game_wrapper.gd
+++ b/scenes/game/game_wrapper.gd
@@ -441,7 +441,7 @@ func submit_discard_to_max(player : Enums.PlayerId, card_ids : Array) -> bool:
 	var game_player = _get_player(player)
 	return current_game.do_discard_to_max(game_player, card_ids)
 
-func submit_card_from_hand_to_gauge(player : Enums.PlayerId, card_ids : Array) -> bool:
+func submit_relocate_card_from_hand(player : Enums.PlayerId, card_ids : Array) -> bool:
 	var game_player = _get_player(player)
 	return current_game.do_relocate_card_from_hand(game_player, card_ids)
 

--- a/scenes/game/game_wrapper.gd
+++ b/scenes/game/game_wrapper.gd
@@ -442,7 +442,7 @@ func submit_discard_to_max(player : Enums.PlayerId, card_ids : Array) -> bool:
 
 func submit_card_from_hand_to_gauge(player : Enums.PlayerId, card_ids : Array) -> bool:
 	var game_player = _get_player(player)
-	return current_game.do_card_from_hand_to_gauge(game_player, card_ids)
+	return current_game.do_relocate_card_from_hand(game_player, card_ids)
 
 func submit_pay_strike_cost(player : Enums.PlayerId, card_ids : Array, wild_strike : bool, discard_ex_first : bool, use_free_force : bool) -> bool:
 	var game_player = _get_player(player)

--- a/scenes/game/local_game.gd
+++ b/scenes/game/local_game.gd
@@ -10307,7 +10307,7 @@ func do_boost_cancel(performing_player : Player, gauge_card_ids : Array, doing_c
 ## the move is not specified, and is instead defined by the currently active
 ## decision.
 func do_relocate_card_from_hand(performing_player : Player, card_ids : Array) -> bool:
-	printlog("SubAction: CARD_HAND_TO_SOMEWHERE by %s: %s" % [get_player_name(performing_player.my_id), card_ids])
+	printlog("SubAction: RELOCATE_CARD_FROM_HAND by %s: %s" % [get_player_name(performing_player.my_id), card_ids])
 	if decision_info.player != performing_player.my_id:
 		printlog("ERROR: Tried to do_relocate_card_from_hand for wrong player.")
 		return false

--- a/scenes/game/local_game.gd
+++ b/scenes/game/local_game.gd
@@ -10303,17 +10303,20 @@ func do_boost_cancel(performing_player : Player, gauge_card_ids : Array, doing_c
 	event_queue += events
 	return true
 
-func do_card_from_hand_to_gauge(performing_player : Player, card_ids : Array) -> bool:
-	printlog("SubAction: CARD_HAND_TO_GAUGE by %s: %s" % [get_player_name(performing_player.my_id), card_ids])
+## Select cards from `performing_player`'s hand to be moved. The destination of
+## the move is not specified, and is instead defined by the currently active
+## decision.
+func do_relocate_card_from_hand(performing_player : Player, card_ids : Array) -> bool:
+	printlog("SubAction: CARD_HAND_TO_SOMEWHERE by %s: %s" % [get_player_name(performing_player.my_id), card_ids])
 	if decision_info.player != performing_player.my_id:
-		printlog("ERROR: Tried to do_card_from_hand_to_gauge for wrong player.")
+		printlog("ERROR: Tried to do_relocate_card_from_hand for wrong player.")
 		return false
 	if game_state != Enums.GameState.GameState_PlayerDecision or decision_info.type != Enums.DecisionType.DecisionType_CardFromHandToGauge:
-		printlog("ERROR: Tried to do_card_from_hand_to_gauge but not in decision state.")
+		printlog("ERROR: Tried to do_relocate_card_from_hand but not in decision state.")
 		return false
 	for card_id in card_ids:
 		if not performing_player.is_card_in_hand(card_id):
-			printlog("ERROR: Tried to do_card_from_hand_to_gauge with card not in hand.")
+			printlog("ERROR: Tried to do_relocate_card_from_hand with card not in hand.")
 			return false
 
 	var events = []
@@ -10328,7 +10331,7 @@ func do_card_from_hand_to_gauge(performing_player : Player, card_ids : Array) ->
 			elif decision_info.destination == "deck":
 				events += performing_player.shuffle_card_from_hand_to_deck(card_id)
 			else:
-				assert(false, "Unknown destination for do_card_from_hand_to_gauge")
+				assert(false, "Unhandled destination %s for do_relocate_card_from_hand" % decision_info.destination)
 
 	# Log message
 	if decision_info.destination == "gauge":

--- a/scenes/game/remote_game.gd
+++ b/scenes/game/remote_game.gd
@@ -221,7 +221,7 @@ func process_discard_to_max(action_message) -> void:
 	var card_ids = action_message['card_ids']
 	local_game.do_discard_to_max(game_player, card_ids)
 
-func do_card_from_hand_to_gauge(player : LocalGame.Player, card_ids : Array) -> bool:
+func do_relocate_card_from_hand(player : LocalGame.Player, card_ids : Array) -> bool:
 	var action_message = {
 		'action_type': 'action_card_from_hand_to_gauge',
 		'player_id': _get_player_remote_id(player),
@@ -233,7 +233,7 @@ func do_card_from_hand_to_gauge(player : LocalGame.Player, card_ids : Array) -> 
 func process_card_from_hand_to_gauge(action_message) -> void:
 	var game_player = _get_player_from_remote_id(action_message['player_id'])
 	var card_ids = action_message['card_ids']
-	local_game.do_card_from_hand_to_gauge(game_player, card_ids)
+	local_game.do_relocate_card_from_hand(game_player, card_ids)
 
 func do_pay_strike_cost(player : LocalGame.Player, card_ids : Array, wild_strike : bool, discard_ex_first : bool, use_free_force : bool = false) -> bool:
 	var action_message = {

--- a/scenes/game/remote_game.gd
+++ b/scenes/game/remote_game.gd
@@ -1,3 +1,10 @@
+#### !!! WARNING !!!
+# This file handles the communication of actions between clients. When a local
+# game calls `do_X`, it transmits a dictionary-like message with key `action:
+# "action_Y"`, which the client on the other side then handles with
+# `process_Z()`. Because this mapping is done through string manipulation, it is
+# important that X == Y == Z.
+
 extends Node
 
 const LocalGame = preload("res://scenes/game/local_game.gd")
@@ -223,14 +230,14 @@ func process_discard_to_max(action_message) -> void:
 
 func do_relocate_card_from_hand(player : LocalGame.Player, card_ids : Array) -> bool:
 	var action_message = {
-		'action_type': 'action_card_from_hand_to_gauge',
+		'action_type': 'action_relocate_card_from_hand',
 		'player_id': _get_player_remote_id(player),
 		'card_ids': card_ids,
 	}
 	_submit_game_message(action_message)
 	return true
 
-func process_card_from_hand_to_gauge(action_message) -> void:
+func process_relocate_card_from_hand(action_message) -> void:
 	var game_player = _get_player_from_remote_id(action_message['player_id'])
 	var card_ids = action_message['card_ids']
 	local_game.do_relocate_card_from_hand(game_player, card_ids)

--- a/test/unit/test_baiken.gd
+++ b/test/unit/test_baiken.gd
@@ -231,7 +231,7 @@ func test_baiken_kabari_boost_pass():
 	give_player_specific_card(player1, "baiken_kabari", TestCardId3)
 	assert_true(game_logic.do_boost(player1, TestCardId3))
 	assert_eq(game_logic.game_state, Enums.GameState.GameState_PlayerDecision)
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, []))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, []))
 	assert_eq(game_logic.game_state, Enums.GameState.GameState_PickAction)
 	assert_eq(game_logic.active_turn_player, player2.my_id)
 
@@ -241,7 +241,7 @@ func test_baiken_kabari_boost_add_card():
 	give_player_specific_card(player1, "baiken_kabari", TestCardId3)
 	assert_true(game_logic.do_boost(player1, TestCardId3))
 	assert_eq(game_logic.game_state, Enums.GameState.GameState_PlayerDecision)
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [TestCardId4]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [TestCardId4]))
 	assert_eq(player1.gauge.size(), 1)
 	assert_true(game_logic.do_boost_cancel(player1, [], false))
 	assert_eq(player1.hand.size(), 6)

--- a/test/unit/test_bison.gd
+++ b/test/unit/test_bison.gd
@@ -216,7 +216,7 @@ func test_bison_ua():
 	assert_eq(player1.hand.size(), 5)
 	var id = player1.hand[0].id
 	assert_true(game_logic.do_character_action(player1, []))
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [id]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [id]))
 	assert_eq(player1.hand.size(), 6)
 	assert_eq(player1.gauge.size(), 1)
 	assert_eq(player1.gauge[0].id, id)
@@ -228,13 +228,13 @@ func test_bison_ua_exceed():
 	assert_true(game_logic.do_exceed(player1, player1.get_card_ids_in_gauge()))
 	assert_eq(player1.hand.size(), 5)
 	var ids = [player1.hand[0].id, player1.hand[1].id, player1.hand[2].id]
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, ids))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, ids))
 	assert_eq(player1.gauge.size(), 3)
 	assert_eq(player1.hand.size(), 6)
 	advance_turn(player2)
 	assert_true(game_logic.do_character_action(player1, []))
 	var new_ids = [player1.hand[0].id, player1.hand[1].id]
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, new_ids))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, new_ids))
 	assert_eq(player1.gauge.size(), 5)
 	assert_eq(player1.hand.size(), 7)
 	advance_turn(player2)

--- a/test/unit/test_dan.gd
+++ b/test/unit/test_dan.gd
@@ -364,7 +364,7 @@ func test_dan_lucky_skip_draw():
 	var initial_hand_size = len(player1.hand)
 	give_player_specific_card(player1, "dan_shissoburaiken", TestCardId3)
 	assert_true(game_logic.do_boost(player1, TestCardId3, []))
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [player1.hand[0].id]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [player1.hand[0].id]))
 	assert_true(game_logic.do_choice(player1, 0))
 	assert_eq(len(player1.hand), initial_hand_size-1)
 	advance_turn(player2)
@@ -431,7 +431,7 @@ func test_dan_legendary_taunt_extra_attack_gadouken():
 		[], [], 0, true)
 	assert_true(game_logic.do_choose_to_discard(player1, [TestCardId3]))
 	assert_true(game_logic.do_choice(player1, 0))
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [to_gauge_id]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [to_gauge_id]))
 
 	validate_life(player1, 30, player2, 26)
 	validate_positions(player1, 3, player2, 7)

--- a/test/unit/test_enchantress.gd
+++ b/test/unit/test_enchantress.gd
@@ -454,7 +454,7 @@ func test_enchantress_rebirth():
 	give_player_specific_card(player1, "standard_normal_grasp", TestCardId4)
 
 	assert_true(game_logic.do_boost(player1, TestCardId1, []))
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [TestCardId2, TestCardId3, TestCardId4]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [TestCardId2, TestCardId3, TestCardId4]))
 	assert_eq(len(player1.hand), 4)
 	assert_eq(player1.deck[len(player1.deck)-1].id, TestCardId4)
 	assert_eq(player1.deck[len(player1.deck)-2].id, TestCardId3)

--- a/test/unit/test_giovanna.gd
+++ b/test/unit/test_giovanna.gd
@@ -206,7 +206,7 @@ func test_gio_charaction_exceeded():
 	assert_true(game_logic.do_exceed(player1, [player1.gauge[0].id, player1.gauge[1].id,player1.gauge[2].id]))
 	var events = game_logic.get_latest_events()
 	validate_has_event(events, Enums.EventType.EventType_CardFromHandToGauge_Choice, player1)
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [player1.hand[0].id]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [player1.hand[0].id]))
 	advance_turn(player2)
 	assert_eq(player1.hand.size(), 5)
 	assert_true(game_logic.do_character_action(player1, [player1.gauge[0].id]))

--- a/test/unit/test_hilda.gd
+++ b/test/unit/test_hilda.gd
@@ -351,11 +351,11 @@ func test_hilda_trifurket_boost():
 	give_player_specific_card(player1, "hilda_trifurket", TestCardId1)
 	assert_true(game_logic.do_boost(player1, TestCardId1))
 
-	assert_true(game_logic.do_card_from_hand_to_gauge(player2, [TestCardId2]))
+	assert_true(game_logic.do_relocate_card_from_hand(player2, [TestCardId2]))
 	var p1cards = []
 	for i in range(3):
 		p1cards.append(player1.hand[i].id)
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, p1cards))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, p1cards))
 
 	validate_positions(player1, 2, player2, 3)
 	assert_eq(player1.gauge.size(), 3)

--- a/test/unit/test_hyde.gd
+++ b/test/unit/test_hyde.gd
@@ -212,7 +212,7 @@ func test_hyde_ua_not_striking():
 	validate_has_event(events, Enums.EventType.EventType_CardFromHandToGauge_Choice, player1)
 	assert_eq(game_logic.game_state, Enums.GameState.GameState_PlayerDecision)
 	var card_to_choose = player1.hand[0]
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [card_to_choose.id]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [card_to_choose.id]))
 	events = game_logic.get_latest_events()
 	assert_true(player1.is_card_in_gauge(card_to_choose.id))
 	validate_positions(player1, 3, player2, 5)

--- a/test/unit/test_mika.gd
+++ b/test/unit/test_mika.gd
@@ -260,7 +260,7 @@ func test_mika_crash_pachelbel():
 	assert_true(game_logic.do_choose_to_discard(player1, [player1.hand[0].id]))
 	assert_true(game_logic.do_choice(player1, 0))
 	assert_true(game_logic.do_boost(player1, TestCardId4))
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [TestCardId3]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [TestCardId3]))
 	execute_strike(player1, player2, "", "uni_normal_focus", [], [])
 	validate_positions(player1, 6, player2, 5)
 	validate_life(player1, 30, player2, 27)

--- a/test/unit/test_nine.gd
+++ b/test/unit/test_nine.gd
@@ -233,7 +233,7 @@ func test_nine_swap_normal():
 
 	execute_strike(player1, player2, "standard_normal_assault","standard_normal_assault", [0], [], false, false)
 	var card_to_choose = player1.hand[0]
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [card_to_choose.id]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [card_to_choose.id]))
 
 	assert_true(player1.is_card_in_gauge(card_to_choose.id))
 	assert_true(player1.is_card_in_sealed(TestCardId1))

--- a/test/unit/test_propeller.gd
+++ b/test/unit/test_propeller.gd
@@ -261,7 +261,7 @@ func test_propeller_swoop_range_three():
 	execute_strike(player1, player2, "propeller_swoop","standard_normal_assault", [2], [], false, false)
 	validate_positions(player1, 8, player2, 5)
 	validate_life(player1, 30, player2, 27)
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [TestCardId3]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [TestCardId3]))
 	assert_true(player1.is_card_in_continuous_boosts(TestCardId1))
 	assert_true(player1.is_card_in_gauge(TestCardId3))
 	advance_turn(player2)

--- a/test/unit/test_ram.gd
+++ b/test/unit/test_ram.gd
@@ -312,7 +312,7 @@ func test_erarlumo_hit():
 	validate_has_event(events, Enums.EventType.EventType_CardFromHandToGauge_Choice, player1)
 	assert_eq(game_logic.game_state, Enums.GameState.GameState_PlayerDecision)
 	var card_to_choose = player1.hand[0]
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [card_to_choose.id]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [card_to_choose.id]))
 	events = game_logic.get_latest_events()
 	assert_true(player1.is_card_in_gauge(card_to_choose.id))
 	validate_positions(player1, 3, player2, 4)

--- a/test/unit/test_randomai.gd
+++ b/test/unit/test_randomai.gd
@@ -182,7 +182,7 @@ func handle_decisions(game: LocalGame):
 				assert_true(game.do_force_for_armor(decision_ai.game_player, forceforarmor_action.card_ids, forceforarmor_action.use_free_force), "do force armor failed")
 			Enums.DecisionType.DecisionType_CardFromHandToGauge:
 				var cardfromhandtogauge_action = decision_ai.pick_card_hand_to_gauge(game, decision_player.my_id, game.decision_info.effect['min_amount'], game.decision_info.effect['max_amount'])
-				assert_true(game.do_card_from_hand_to_gauge(decision_ai.game_player, cardfromhandtogauge_action.card_ids), "do card hand strike failed")
+				assert_true(game.do_relocate_card_from_hand(decision_ai.game_player, cardfromhandtogauge_action.card_ids), "do card hand strike failed")
 			Enums.DecisionType.DecisionType_ForceForEffect:
 				var effect = game.decision_info.effect
 				var options = []

--- a/test/unit/test_taokaka.gd
+++ b/test/unit/test_taokaka.gd
@@ -233,7 +233,7 @@ func test_taokaka_hexaedge_becomingtwo():
 	assert_true(game_logic.do_boost(player1, TestCardId3, [player1.hand[0].id]))
 	give_player_specific_card(player1, "standard_normal_cross", TestCardId4)
 	give_player_specific_card(player2, "standard_normal_sweep", TestCardId2)
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [TestCardId4]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [TestCardId4]))
 	assert_true(game_logic.do_strike(player1, -1, true, -1))
 	assert_true(game_logic.do_strike(player2, TestCardId2, false, -1))
 	validate_positions(player1, 4, player2, 6)

--- a/test/unit/test_vatista.gd
+++ b/test/unit/test_vatista.gd
@@ -317,7 +317,7 @@ func test_vatista_armabellum_no_cards():
 	give_gauge(player1, 1)
 
 	execute_strike(player1, player2, "vatista_armabellum", "uni_normal_grasp", [], [], false, false)
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, []))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, []))
 	assert_true(game_logic.do_choice(player1, 1))
 	validate_positions(player1, 2, player2, 5)
 	validate_life(player1, 30, player2, 28)
@@ -328,7 +328,7 @@ func test_vatista_armabellum_add_cards():
 	give_gauge(player1, 1)
 
 	execute_strike(player1, player2, "vatista_armabellum", "uni_normal_grasp", [], [], false, false)
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [player1.hand[0].id, player1.hand[1].id, player1.hand[2].id]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [player1.hand[0].id, player1.hand[1].id, player1.hand[2].id]))
 	assert_true(game_logic.do_choice(player1, 0))
 	validate_positions(player1, 4, player2, 5)
 	validate_life(player1, 30, player2, 25)

--- a/test/unit/test_yuzu.gd
+++ b/test/unit/test_yuzu.gd
@@ -14,7 +14,7 @@ func test_yuzu_ua_under_four_gauge():
 	validate_has_event(events, Enums.EventType.EventType_CardFromHandToGauge_Choice, player1)
 	assert_eq(game_logic.game_state, Enums.GameState.GameState_PlayerDecision)
 	var card_to_choose = player1.hand[0]
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [card_to_choose.id]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [card_to_choose.id]))
 	events = game_logic.get_latest_events()
 	assert_true(player1.is_card_in_gauge(card_to_choose.id))
 
@@ -30,7 +30,7 @@ func test_yuzu_ua_four_gauge():
 	validate_has_event(events, Enums.EventType.EventType_CardFromHandToGauge_Choice, player1)
 	assert_eq(game_logic.game_state, Enums.GameState.GameState_PlayerDecision)
 	var card_to_choose = player1.hand[0]
-	assert_true(game_logic.do_card_from_hand_to_gauge(player1, [card_to_choose.id]))
+	assert_true(game_logic.do_relocate_card_from_hand(player1, [card_to_choose.id]))
 	events = game_logic.get_latest_events()
 	assert_true(player1.is_card_in_gauge(card_to_choose.id))
 


### PR DESCRIPTION
It moves the card from hand to *wherever the current decision wants them to go*.

There are no more hits for `do_card_from_hand_to_gauge` in the codebase, and all the unit tests pass, so this should be complete and correct.