### PR TITLE
Fix Gordeau Snatcher and Teching your own tech

### DIFF
--- a/globals/global_settings.gd
+++ b/globals/global_settings.gd
@@ -3,7 +3,7 @@ extends Node
 const ReleaseLoggingEnabled = false # If true, log even on release builds.
 const UseAzureServerAlways = true # If true, always defaults to the azure server.
 var MuteEmotes = false
-const ClientVersionString : String = "240404.2000" # YYMMDD.HHMM
+const ClientVersionString : String = "240505.1500" # YYMMDD.HHMM
 
 const CharacterBanlist = ['carmine']
 

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -1067,6 +1067,8 @@ func can_select_card(card):
 			var limitation = game_wrapper.get_decision_info().limitation
 			if limitation in ["mine", "in_opponent_space"] and in_opponent_boosts:
 				return false
+			if not in_player_boosts and not in_opponent_boosts:
+				return false
 			if len(selected_cards) < select_card_require_max:
 				var card_db = game_wrapper.get_card_database()
 				var logic_card = card_db.get_card(card.card_id)

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -41,6 +41,7 @@ const LocationInfoButtonPair = preload("res://scenes/game/location_infobutton_pa
 @onready var modal_dialog : ModalDialog = $ModalDialog
 
 const OffScreen = Vector2(-1000, -1000)
+const ChoiceCopyIdRangeStart = 70000
 const RevealCopyIdRangestart = 80000
 const ReferenceScreenIdRangeStart = 90000
 const NoticeOffsetY = 50
@@ -1744,7 +1745,7 @@ func begin_choose_opponent_card_to_discard(card_ids):
 	for card_id in card_ids:
 		var logic_card : GameCard = card_db.get_card(card_id)
 		var card_image = get_card_image_path(opponent_deck['id'], logic_card)
-		var copy_card = create_card(card_id + RevealCopyIdRangestart, logic_card.definition, card_image, "", choice_zone_parent, true)
+		var copy_card = create_card(card_id + ChoiceCopyIdRangeStart, logic_card.definition, card_image, "", choice_zone_parent, true)
 		copy_card.set_card_and_focus(OffScreen, 0, CardBase.ReferenceCardScale)
 		copy_card.resting_scale = CardBase.ReferenceCardScale
 		copy_card.change_state(CardBase.CardState.CardState_Offscreen)
@@ -4177,7 +4178,7 @@ func _on_instructions_ok_button_pressed(index : int):
 				var chosen_action = action_choices[index]
 				success = game_wrapper.submit_choose_from_topdeck(Enums.PlayerId.PlayerId_Player, single_card_id, chosen_action)
 			UISubState.UISubState_SelectCards_ChooseOpponentCardToDiscard:
-				var adjusted_id = single_card_id - RevealCopyIdRangestart
+				var adjusted_id = single_card_id - ChoiceCopyIdRangeStart
 				success = game_wrapper.submit_choose_to_discard(Enums.PlayerId.PlayerId_Player, [adjusted_id])
 				clear_choice_zone()
 			UISubState.UISubState_SelectCards_ChooseDiscardToDestination:

--- a/work.todo
+++ b/work.todo
@@ -1,10 +1,10 @@
 
 
 In progress:
-
-
+    ☐ Tager exceed is may
 Bug:
     Breaking:
+        ☐ Gordeau - Snatcher boost, don't let player select cards from the Known Cards then reopen to discard.
         ☐ Review mid-strike Tech interactions:
             - Faust remove boost effects needs to be reviewed, stuff like powerup_opponent and other random effects that Faust can remove mid-strike
             - probably any during_strike ability?
@@ -36,6 +36,9 @@ Tasks:
     Main Features:
         ☐ Search for match while observing/playing AI
         ☐ Match available notification while you're observing
+        ☐ Rematch button
+        ☐ Rejoin after disconnect
+        ☐ Are you sure when playing tech effect boost that does nothing
     High Pri UI Improvements:
         ☐ Background image + life panel backgrounds
         ☐ Card popout has choice buttons for gauge selection

--- a/work.todo
+++ b/work.todo
@@ -4,7 +4,6 @@ In progress:
     ☐ Tager exceed is may
 Bug:
     Breaking:
-        ☐ Gordeau - Snatcher boost, don't let player select cards from the Known Cards then reopen to discard.
         ☐ Review mid-strike Tech interactions:
             - Faust remove boost effects needs to be reviewed, stuff like powerup_opponent and other random effects that Faust can remove mid-strike
             - probably any during_strike ability?


### PR DESCRIPTION
1. Gordeau's Snatcher could get weird because the reference known card ids matched the choice zone card ids. This makes it so they have their own ID range and behave nicely.
2. You could select the Dive card you boosted as a card to discard, which didn't make any sense. You should only be able to discard boosts in the continuous boost area.