### PR TITLE
Flesh out AI-internal objects for representing game state

### DIFF
--- a/scenes/game/ai/ai_policy_random.gd
+++ b/scenes/game/ai/ai_policy_random.gd
@@ -1,6 +1,5 @@
+class_name AIPolicyRandom
 extends Node
-
-const AIPlayer = preload("res://scenes/game/ai_player.gd")
 
 func pick_turn_action(possible_actions : Array, _ai_game_state : AIPlayer.AIGameState):
 	return possible_actions[randi() % len(possible_actions)]

--- a/scenes/game/ai/ai_policy_rules.gd
+++ b/scenes/game/ai/ai_policy_rules.gd
@@ -219,7 +219,7 @@ func pick_turn_action(possible_actions : Array, ai_game_state : AIPlayer.AIGameS
 
 		# Try to character action.
 		var skip_character_action = false
-		if ai_game_state.my_state.deck_id == 'bison' and ai_game_state.my_state.gauge.size() > 3:
+		if ai_game_state.my_state.kit['id'] == 'bison' and ai_game_state.my_state.gauge.size() > 3:
 			# Bison AI takes way too long when it builds up tons of gauge.
 			skip_character_action = true
 

--- a/scenes/game/ai/ai_policy_rules.gd
+++ b/scenes/game/ai/ai_policy_rules.gd
@@ -219,7 +219,7 @@ func pick_turn_action(possible_actions : Array, ai_game_state : AIPlayer.AIGameS
 
 		# Try to character action.
 		var skip_character_action = false
-		if ai_game_state.my_state.kit['id'] == 'bison' and ai_game_state.my_state.gauge.size() > 3:
+		if ai_game_state.my_state.deck_def['id'] == 'bison' and ai_game_state.my_state.gauge.size() > 3:
 			# Bison AI takes way too long when it builds up tons of gauge.
 			skip_character_action = true
 

--- a/scenes/game/ai_player.gd
+++ b/scenes/game/ai_player.gd
@@ -28,7 +28,6 @@
 ##         the top of a turn; for example, a mid-strike decision on movement.
 
 class_name AIPlayer
-extends Node2D
 
 const TEST_PrepareOnly = false
 
@@ -45,7 +44,7 @@ var ai_policy
 var game_player: LocalGame.Player
 var game_opponent: LocalGame.Player
 
-func initialize(local_game: LocalGame, player: LocalGame.Player, policy = null):
+func _init(local_game: LocalGame, player: LocalGame.Player, policy = null):
 	game_logic = local_game
 	game_player = player
 	game_opponent = local_game._get_player(local_game.get_other_player(player.my_id))
@@ -126,7 +125,7 @@ class AIPlayerState:
 			if name in AIPlayer.IGNORE_PROPERTIES or name == 'source':
 				continue
 
-			var value = self._get(name)
+			var value = self.get(name)
 			if value == null:
 				new_state._set(name, null)
 				continue
@@ -172,7 +171,7 @@ class AIStrikeState:
 			if name in AIPlayer.IGNORE_PROPERTIES or name == 'source':
 				continue
 
-			var value = self._get(name)
+			var value = self.get(name)
 			if value == null:
 				new_state._set(name, null)
 				continue
@@ -230,7 +229,7 @@ class AIGameState:
 			if name in AIPlayer.IGNORE_PROPERTIES or name == 'source':
 				continue
 
-			var value = self._get(name)
+			var value = self.get(name)
 			if value == null:
 				new_state._set(name, null)
 				continue

--- a/scenes/game/ai_player.gd
+++ b/scenes/game/ai_player.gd
@@ -1,4 +1,4 @@
-## Basic framework for AI behavior.
+## AI player controller object.
 
 ## This file describes a bunch of hooks and basic functions used to provide an
 ## AI with options, then relay the AI's choice from those options back to the
@@ -6,16 +6,18 @@
 ## [i]policy[/i], which is a Node that implements the laundry list of pick_*
 ## functions. See ai_random_policy.gd for a very basic (but complete!) example.
 
-## After initialization, the main entry point into the code is through
-## [method take_turn], which is called by game.gd's `ai_take_turn`. `take_turn`
-## accepts a summary of the game state and returns an instance of one of the
-## various *Action classes defined in this file. `ai_take_turn` then uses
-## that return value to manifest the appropriate changes in the game proper.
+## The player is initialized with a reference to the relevant game and player
+## objects. After that, the main entry point into the code is through [method take_turn],
+## which is called by game.gd's `ai_take_turn`. `take_turn` consults the stored
+## game state the game state and returns an instance of one of the various
+## *Action classes defined in this file. `ai_take_turn` then uses that return
+## value to manifest the appropriate changes in the game proper.
 
-## `take_turn` enumerates all legal actions for the AI to take, then passes
-## them to policy and handles the return. Note that each possible variant of
-## a (game) action counts as a distinct (AI) action; for example, the choice
-## of which cards to discard for Force generation during a Walk.
+## `take_turn` enumerates all legal actions for the AI to take, then passes them
+## to policy (and then forwards the return value back to game.gd as described
+## above). Note that each possible variant of a (game) action counts as a
+## distinct (AI) action; for example, the choice of which cards to discard for
+## Force generation during a Walk.
 
 ## A broad overview of the main chunks of this file:
 

--- a/scenes/game/ai_player.gd
+++ b/scenes/game/ai_player.gd
@@ -48,7 +48,7 @@ var game_opponent: LocalGame.Player
 func _init(local_game: LocalGame, player: LocalGame.Player, policy = null):
 	game_logic = local_game
 	game_player = player
-	game_opponent = local_game.get_player(local_game.get_other_player(player.my_id))
+	game_opponent = local_game._get_player(local_game.get_other_player(player.my_id))
 	game_state = AIGameState.new(game_logic, game_player, game_opponent)
 	if policy == null:
 		ai_policy = AIPolicyRules.new()
@@ -81,6 +81,11 @@ class AIPlayerState:
 	var player_id : Enums.PlayerId
 	var life
 	var deck
+	# `kit` is the character-defining JSON, which contains the UA/XA and
+	# anything else that isn't a deck card proper
+	var kit
+	# `full_deck` is the full definitions of the actual cards in the deck,
+	# including Astral Heats
 	var full_deck
 	var hand
 	var discards
@@ -102,6 +107,7 @@ class AIPlayerState:
 		player_id = source.my_id
 		life = source.life
 		deck = AIPlayer.create_card_id_array(source.deck)
+		kit = source.deck_def
 		full_deck = source.deck_list
 		hand = AIPlayer.create_card_id_array(source.hand)
 		discards = AIPlayer.create_card_id_array(source.discards)

--- a/scenes/game/ai_player.gd
+++ b/scenes/game/ai_player.gd
@@ -45,7 +45,7 @@ var ai_policy
 var game_player: LocalGame.Player
 var game_opponent: LocalGame.Player
 
-func _init(local_game: LocalGame, player: LocalGame.Player, policy = null):
+func initialize(local_game: LocalGame, player: LocalGame.Player, policy = null):
 	game_logic = local_game
 	game_player = player
 	game_opponent = local_game._get_player(local_game.get_other_player(player.my_id))
@@ -97,9 +97,9 @@ class AIPlayerState:
 	var exceeded
 	var reshuffle_remaining
 
-	func _init(player: LocalGame.Player, update: bool = true):
+	func _init(player: LocalGame.Player, do_update: bool = true):
 		source = player
-		if update:
+		if do_update:
 			self.update()
 
 	## Syncs the data into this object to the state of the actual game.
@@ -159,12 +159,12 @@ class AIStrikeState:
 		if self.active:
 			var source = game_logic.active_strike
 			self.initiator = source.initiator.my_id
-			
+
 			self.initiator_card_id = source.initiator_card.id if source.initiator_card else -1
 			self.initiator_ex_card_id = source.initiator_ex_card.id if source.initiator_ex_card else -1
 			self.defender_card_id = source.defender_card.id if source.defender_card else -1
 			self.defender_ex_card_id = source.defender_ex_card.id if source.defender_ex_card else -1
-			
+
 	func duplicate(deep: bool = true):
 		var new_state = AIStrikeState.new()
 		for property in self.get_property_list():
@@ -191,7 +191,7 @@ class AIStrikeState:
 				new_state._set(name, value)
 		return new_state
 
-			
+
 class AIGameState:
 	var source: LocalGame
 	var player: LocalGame.Player
@@ -204,17 +204,17 @@ class AIGameState:
 
 	func _init(
 			game_logic: LocalGame,
-			player: LocalGame.Player = null,
-			opponent: LocalGame.Player = null,
-			update: bool = true):
+			the_player: LocalGame.Player = null,
+			the_opponent: LocalGame.Player = null,
+			do_update: bool = true):
 		self.source = game_logic
 		self.card_db = game_logic.get_card_database()
-		self.player = player
-		self.opponent = opponent
-		my_state = AIPlayerState.new(player, false)
-		opponent_state = AIPlayerState.new(opponent, false)
+		self.player = the_player
+		self.opponent = the_opponent
+		my_state = AIPlayerState.new(the_player, false)
+		opponent_state = AIPlayerState.new(the_opponent, false)
 		active_strike = AIStrikeState.new()
-		if update:
+		if do_update:
 			self.update()
 
 	func update():
@@ -249,7 +249,7 @@ class AIGameState:
 				new_state._set(name, value)
 		return new_state
 
-	
+
 class PrepareAction:
 	pass
 

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -41,6 +41,7 @@ const LocationInfoButtonPair = preload("res://scenes/game/location_infobutton_pa
 @onready var modal_dialog : ModalDialog = $ModalDialog
 
 const OffScreen = Vector2(-1000, -1000)
+const ChoiceCopyIdRangeStart = 70000
 const RevealCopyIdRangestart = 80000
 const ReferenceScreenIdRangeStart = 90000
 const NoticeOffsetY = 50
@@ -1069,6 +1070,8 @@ func can_select_card(card):
 			var limitation = game_wrapper.get_decision_info().limitation
 			if limitation in ["mine", "in_opponent_space"] and in_opponent_boosts:
 				return false
+			if not in_player_boosts and not in_opponent_boosts:
+				return false
 			if len(selected_cards) < select_card_require_max:
 				var card_db = game_wrapper.get_card_database()
 				var logic_card = card_db.get_card(card.card_id)
@@ -1744,7 +1747,7 @@ func begin_choose_opponent_card_to_discard(card_ids):
 	for card_id in card_ids:
 		var logic_card : GameCard = card_db.get_card(card_id)
 		var card_image = get_card_image_path(opponent_deck['id'], logic_card)
-		var copy_card = create_card(card_id + RevealCopyIdRangestart, logic_card.definition, card_image, "", choice_zone_parent, true)
+		var copy_card = create_card(card_id + ChoiceCopyIdRangeStart, logic_card.definition, card_image, "", choice_zone_parent, true)
 		copy_card.set_card_and_focus(OffScreen, 0, CardBase.ReferenceCardScale)
 		copy_card.resting_scale = CardBase.ReferenceCardScale
 		copy_card.change_state(CardBase.CardState.CardState_Offscreen)
@@ -4177,7 +4180,7 @@ func _on_instructions_ok_button_pressed(index : int):
 				var chosen_action = action_choices[index]
 				success = game_wrapper.submit_choose_from_topdeck(Enums.PlayerId.PlayerId_Player, single_card_id, chosen_action)
 			UISubState.UISubState_SelectCards_ChooseOpponentCardToDiscard:
-				var adjusted_id = single_card_id - RevealCopyIdRangestart
+				var adjusted_id = single_card_id - ChoiceCopyIdRangeStart
 				success = game_wrapper.submit_choose_to_discard(Enums.PlayerId.PlayerId_Player, [adjusted_id])
 				clear_choice_zone()
 			UISubState.UISubState_SelectCards_ChooseDiscardToDestination:

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -13,7 +13,6 @@ const CardPopout = preload("res://scenes/game/card_popout.gd")
 const CardPopoutScene = preload("res://scenes/game/card_popout.tscn")
 const GaugePanel = preload("res://scenes/game/gauge_panel.gd")
 const CharacterCardBase = preload("res://scenes/card/character_card_base.gd")
-const AIPlayer = preload("res://scenes/game/ai_player.gd")
 const DamagePopup = preload("res://scenes/game/damage_popup.gd")
 const Character = preload("res://scenes/game/character.gd")
 const CharacterScene = preload("res://scenes/game/character.tscn")
@@ -290,8 +289,7 @@ func _ready():
 			$PlayerLife.set_clock(GameTimerLength)
 			$OpponentLife.set_clock(GameTimerLength)
 	else:
-		ai_player = $AIPlayer
-		ai_player.initialize(game_wrapper.current_game, game_wrapper.current_game.opponent)
+		ai_player = AIPlayer.new(game_wrapper.current_game, game_wrapper.current_game.opponent)
 
 	$PlayerLife.set_life(game_wrapper.get_player_life(Enums.PlayerId.PlayerId_Player))
 	$OpponentLife.set_life(game_wrapper.get_player_life(Enums.PlayerId.PlayerId_Opponent))

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -289,7 +289,7 @@ func _ready():
 			$PlayerLife.set_clock(GameTimerLength)
 			$OpponentLife.set_clock(GameTimerLength)
 	else:
-		ai_player = AIPlayer.new(game_wrapper.current_game)
+		ai_player = AIPlayer.new(game_wrapper.current_game, game_wrapper.current_game.opponent)
 
 	$PlayerLife.set_life(game_wrapper.get_player_life(Enums.PlayerId.PlayerId_Player))
 	$OpponentLife.set_life(game_wrapper.get_player_life(Enums.PlayerId.PlayerId_Opponent))
@@ -4523,7 +4523,7 @@ func ai_take_turn():
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
 	var success = false
-	var turn_action = ai_player.take_turn(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent)
+	var turn_action = ai_player.take_turn()
 	if turn_action is AIPlayer.PrepareAction:
 		success = ai_handle_prepare()
 	elif turn_action is AIPlayer.MoveAction:

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -290,7 +290,8 @@ func _ready():
 			$PlayerLife.set_clock(GameTimerLength)
 			$OpponentLife.set_clock(GameTimerLength)
 	else:
-		ai_player = AIPlayer.new(game_wrapper.current_game, game_wrapper.current_game.opponent)
+		ai_player = $AIPlayer
+		ai_player.initialize(game_wrapper.current_game, game_wrapper.current_game.opponent)
 
 	$PlayerLife.set_life(game_wrapper.get_player_life(Enums.PlayerId.PlayerId_Player))
 	$OpponentLife.set_life(game_wrapper.get_player_life(Enums.PlayerId.PlayerId_Opponent))

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -4551,7 +4551,7 @@ func ai_take_turn():
 func ai_do_boost(valid_zones : Array, limitation : String, ignore_costs : bool = false, boost_amount : int = 1):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var boost_action = ai_player.take_boost(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, valid_zones, limitation, ignore_costs, boost_amount)
+	var boost_action = ai_player.take_boost(valid_zones, limitation, ignore_costs, boost_amount)
 	var success = ai_handle_boost(boost_action)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4564,9 +4564,9 @@ func ai_pay_cost(cost, is_force_cost : bool):
 	var can_wild = game_wrapper.get_decision_info().type == Enums.DecisionType.DecisionType_PayStrikeCost_CanWild
 	var pay_action
 	if is_force_cost:
-		pay_action = ai_player.pay_strike_force_cost(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, cost, can_wild)
+		pay_action = ai_player.pay_strike_force_cost(cost, can_wild)
 	else:
-		pay_action = ai_player.pay_strike_gauge_cost(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, cost, can_wild)
+		pay_action = ai_player.pay_strike_gauge_cost(cost, can_wild)
 	var success = game_wrapper.submit_pay_strike_cost(Enums.PlayerId.PlayerId_Opponent, pay_action.card_ids, pay_action.wild_swing, false, pay_action.use_free_force)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4576,7 +4576,7 @@ func ai_pay_cost(cost, is_force_cost : bool):
 func ai_effect_choice(_event):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var effect_action = ai_player.pick_effect_choice(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent)
+	var effect_action = ai_player.pick_effect_choice()
 	var success = game_wrapper.submit_choice(Enums.PlayerId.PlayerId_Opponent, effect_action.choice)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4588,7 +4588,7 @@ func ai_force_for_armor(_event):
 	if not game_wrapper.is_ai_game(): return
 	var decision_info = game_wrapper.get_decision_info()
 	var use_gauge_instead = decision_info.limitation == "gauge"
-	var forceforarmor_action = ai_player.pick_force_for_armor(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, use_gauge_instead)
+	var forceforarmor_action = ai_player.pick_force_for_armor(use_gauge_instead)
 	var success = game_wrapper.submit_force_for_armor(Enums.PlayerId.PlayerId_Opponent, forceforarmor_action.card_ids, forceforarmor_action.use_free_force)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4607,7 +4607,7 @@ func ai_force_for_effect(effect):
 		if not required:
 			options.append(0)
 		options.append(effect['force_max'])
-	var forceforeffect_action = ai_player.pick_force_for_effect(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, options)
+	var forceforeffect_action = ai_player.pick_force_for_effect(options)
 	var success = game_wrapper.submit_force_for_effect(Enums.PlayerId.PlayerId_Opponent, forceforeffect_action.card_ids, false, false, forceforeffect_action.use_free_force)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4625,7 +4625,7 @@ func ai_gauge_for_effect(effect):
 		if not 'required' in effect or not effect['required']:
 			options.append(0)
 		options.append(effect['gauge_max'])
-	var gauge_action = ai_player.pick_gauge_for_effect(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, options)
+	var gauge_action = ai_player.pick_gauge_for_effect(options)
 	var success = game_wrapper.submit_gauge_for_effect(Enums.PlayerId.PlayerId_Opponent, gauge_action.card_ids)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4635,7 +4635,7 @@ func ai_gauge_for_effect(effect):
 func ai_strike_response():
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var response_action = ai_player.pick_strike_response(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent)
+	var response_action = ai_player.pick_strike_response()
 	var success = game_wrapper.submit_strike(Enums.PlayerId.PlayerId_Opponent, response_action.card_id, response_action.wild_swing, response_action.ex_card_id)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4654,7 +4654,7 @@ func ai_strike_effect_do_strike(card_id : int, wild_swing : bool, ex_card_id : i
 func ai_discard(event):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var discard_action = ai_player.pick_discard_to_max(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, event['number'])
+	var discard_action = ai_player.pick_discard_to_max(event['number'])
 	var success = game_wrapper.submit_discard_to_max(Enums.PlayerId.PlayerId_Opponent, discard_action.card_ids)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4664,19 +4664,19 @@ func ai_discard(event):
 func ai_forced_strike(disable_wild_swing : bool = false, disable_ex : bool = false, require_ex : bool = false):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var strike_action = ai_player.pick_strike(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, "", disable_wild_swing, disable_ex, require_ex)
+	var strike_action = ai_player.pick_strike("", disable_wild_swing, disable_ex, require_ex)
 	ai_handle_strike(strike_action)
 
 func ai_strike_from_gauge(source : String):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var strike_action = ai_player.pick_strike(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, source)
+	var strike_action = ai_player.pick_strike(source)
 	ai_handle_strike(strike_action)
 
 func ai_boost_cancel_decision(gauge_cost):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var cancel_action = ai_player.pick_cancel(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, gauge_cost)
+	var cancel_action = ai_player.pick_cancel(gauge_cost)
 	var success = game_wrapper.submit_boost_cancel(Enums.PlayerId.PlayerId_Opponent, cancel_action.card_ids, cancel_action.cancel)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4686,7 +4686,7 @@ func ai_boost_cancel_decision(gauge_cost):
 func ai_discard_continuous_boost(limitation, can_pass, boost_name_restriction):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var pick_action = ai_player.pick_discard_continuous(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent,limitation, can_pass, boost_name_restriction)
+	var pick_action = ai_player.pick_discard_continuous(limitation, can_pass, boost_name_restriction)
 	var success = game_wrapper.submit_boost_name_card_choice_effect(Enums.PlayerId.PlayerId_Opponent, pick_action.card_id)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4696,7 +4696,7 @@ func ai_discard_continuous_boost(limitation, can_pass, boost_name_restriction):
 func ai_discard_opponent_gauge():
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var pick_action = ai_player.pick_discard_opponent_gauge(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent)
+	var pick_action = ai_player.pick_discard_opponent_gauge()
 	var success = game_wrapper.submit_boost_name_card_choice_effect(Enums.PlayerId.PlayerId_Opponent, pick_action.card_id)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4706,7 +4706,7 @@ func ai_discard_opponent_gauge():
 func ai_name_opponent_card(normal_only : bool, can_use_own_reference : bool):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var pick_action = ai_player.pick_name_opponent_card(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, normal_only, can_use_own_reference)
+	var pick_action = ai_player.pick_name_opponent_card(normal_only, can_use_own_reference)
 	var success = game_wrapper.submit_boost_name_card_choice_effect(Enums.PlayerId.PlayerId_Opponent, pick_action.card_id)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4716,7 +4716,7 @@ func ai_name_opponent_card(normal_only : bool, can_use_own_reference : bool):
 func ai_choose_card_hand_to_gauge(min_amount, max_amount):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var cardfromhandtogauge_action = ai_player.pick_card_hand_to_gauge(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, min_amount, max_amount)
+	var cardfromhandtogauge_action = ai_player.pick_card_hand_to_gauge(min_amount, max_amount)
 	var success = game_wrapper.submit_relocate_card_from_hand(Enums.PlayerId.PlayerId_Opponent, cardfromhandtogauge_action.card_ids)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4726,7 +4726,7 @@ func ai_choose_card_hand_to_gauge(min_amount, max_amount):
 func ai_choose_from_boosts(amount : int):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var choose_action = ai_player.pick_choose_from_boosts(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, amount)
+	var choose_action = ai_player.pick_choose_from_boosts(amount)
 	var success = game_wrapper.submit_choose_from_boosts(Enums.PlayerId.PlayerId_Opponent, choose_action.card_ids)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4736,7 +4736,7 @@ func ai_choose_from_boosts(amount : int):
 func ai_choose_from_discard(amount : int):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var discard_action = ai_player.pick_choose_from_discard(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, amount)
+	var discard_action = ai_player.pick_choose_from_discard(amount)
 	var success = game_wrapper.submit_choose_from_discard(Enums.PlayerId.PlayerId_Opponent, discard_action.card_ids)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4746,7 +4746,7 @@ func ai_choose_from_discard(amount : int):
 func ai_mulligan_decision():
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var mulligan_action = ai_player.pick_mulligan(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent)
+	var mulligan_action = ai_player.pick_mulligan()
 	var success = game_wrapper.submit_mulligan(Enums.PlayerId.PlayerId_Opponent, mulligan_action.card_ids)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4757,7 +4757,7 @@ func ai_mulligan_decision():
 func ai_choose_to_discard(amount, limitation, can_pass, allow_fewer):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var discard_action = ai_player.pick_choose_to_discard(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, amount, limitation, can_pass, allow_fewer)
+	var discard_action = ai_player.pick_choose_to_discard(amount, limitation, can_pass, allow_fewer)
 	var success = game_wrapper.submit_choose_to_discard(Enums.PlayerId.PlayerId_Opponent, discard_action.card_ids)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4767,7 +4767,7 @@ func ai_choose_to_discard(amount, limitation, can_pass, allow_fewer):
 func ai_choose_from_topdeck(action_choices : Array, look_amount : int, can_pass : bool):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var choose_topdeck_action = ai_player.pick_choose_from_topdeck(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, action_choices, look_amount, can_pass)
+	var choose_topdeck_action = ai_player.pick_choose_from_topdeck(action_choices, look_amount, can_pass)
 	var success = game_wrapper.submit_choose_from_topdeck(Enums.PlayerId.PlayerId_Opponent, choose_topdeck_action.card_id, choose_topdeck_action.action)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4777,7 +4777,7 @@ func ai_choose_from_topdeck(action_choices : Array, look_amount : int, can_pass 
 func ai_choose_opponent_card_to_discard(card_ids : Array):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var discard_action = ai_player.pick_choose_opponent_card_to_discard(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, card_ids)
+	var discard_action = ai_player.pick_choose_opponent_card_to_discard(card_ids)
 	var success = game_wrapper.submit_choose_to_discard(Enums.PlayerId.PlayerId_Opponent, discard_action.card_ids)
 	if success:
 		change_ui_state(UIState.UIState_WaitForGameServer)
@@ -4787,7 +4787,7 @@ func ai_choose_opponent_card_to_discard(card_ids : Array):
 func ai_choose_arena_location_for_effect(location_choices : Array):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var choose_location_action = ai_player.pick_choose_arena_location_for_effect(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, location_choices)
+	var choose_location_action = ai_player.pick_choose_arena_location_for_effect(location_choices)
 	var chosen_location = choose_location_action.location
 	var choice_index = 0
 	for i in range(len(location_choices)):
@@ -4803,7 +4803,7 @@ func ai_choose_arena_location_for_effect(location_choices : Array):
 func ai_pick_number_from_range(choices : Array, effects : Array):
 	change_ui_state(UIState.UIState_WaitForGameServer)
 	if not game_wrapper.is_ai_game(): return
-	var choose_action = ai_player.pick_number_from_range_for_effect(game_wrapper.current_game, Enums.PlayerId.PlayerId_Opponent, choices, effects)
+	var choose_action = ai_player.pick_number_from_range_for_effect(choices, effects)
 	var chosen_number = choose_action.number
 	var choice_index = 0
 	for i in range(len(choices)):

--- a/scenes/game/game.tscn
+++ b/scenes/game/game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=3 uid="uid://dh7wmx6cbb55x"]
+[gd_scene load_steps=27 format=3 uid="uid://dh7wmx6cbb55x"]
 
 [ext_resource type="Script" path="res://scenes/game/game.gd" id="1_4f5jr"]
 [ext_resource type="Texture2D" uid="uid://dh8tat2r8ttx1" path="res://assets/cards/card_border_highlight.png" id="4_5y76h"]
@@ -19,7 +19,6 @@
 [ext_resource type="PackedScene" uid="uid://dal56iqk5k8rh" path="res://scenes/game/action_menu.tscn" id="17_8hgvk"]
 [ext_resource type="Texture2D" uid="uid://cj7nvglef8cu" path="res://assets/cards/solbadguy/normal_grasp.tres" id="17_acwgt"]
 [ext_resource type="Texture2D" uid="uid://mn1hj4i3k7l7" path="res://assets/cards/card_border_highlight_selected.png" id="17_rr8uh"]
-[ext_resource type="Script" path="res://scenes/game/ai_player.gd" id="18_hlntt"]
 [ext_resource type="PackedScene" uid="uid://dvan4a8ftuplj" path="res://scenes/card/character_card_base.tscn" id="18_imast"]
 [ext_resource type="PackedScene" uid="uid://w87ls4e8oasj" path="res://scenes/game/combat_log.tscn" id="18_k7mnw"]
 [ext_resource type="Texture2D" uid="uid://hj14gadm15wr" path="res://assets/icons/speechbubble.png" id="21_86687"]
@@ -30,9 +29,6 @@
 
 [node name="GameScene" type="Node2D"]
 script = ExtResource("1_4f5jr")
-
-[node name="AIPlayer" type="Node2D" parent="."]
-script = ExtResource("18_hlntt")
 
 [node name="Background" type="ColorRect" parent="."]
 offset_right = 1280.0

--- a/scenes/game/local_game.gd
+++ b/scenes/game/local_game.gd
@@ -3258,6 +3258,8 @@ func get_player_name(player_id : Enums.PlayerId) -> String:
 		return player.name
 	return opponent.name
 
+# TODO: This function is frequently called from outside and probably shouldn't
+# start with an underscore.
 func _get_player(player_id : Enums.PlayerId) -> Player:
 	if player_id == Enums.PlayerId.PlayerId_Player:
 		return player

--- a/test/unit/test_randomai.gd
+++ b/test/unit/test_randomai.gd
@@ -23,8 +23,10 @@ func game_setup(policy_type = AIPolicyRules):
 	game_logic.get_latest_events()
 	player1 = game_logic.player
 	player2 = game_logic.opponent
-	ai1 = AIPlayer.new(game_logic, player1, policy_type.new())
-	ai2 = AIPlayer.new(game_logic, player2, policy_type.new())
+	ai1 = AIPlayer.new()
+	ai1.initialize(game_logic, player1, policy_type.new())
+	ai2 = AIPlayer.new()
+	ai2.initialize(game_logic, player2, policy_type.new())
 
 func game_teardown():
 	# TODO: Move this logic into the real game so that it doesn't memory leak

--- a/test/unit/test_randomai.gd
+++ b/test/unit/test_randomai.gd
@@ -31,9 +31,7 @@ func game_teardown():
 	game_logic.teardown()
 	game_logic.free()
 	ai1.ai_policy.free()
-	ai1.free()
 	ai2.ai_policy.free()
-	ai2.free()
 
 func validate_has_event(events, event_type, event_player, number = null):
 	for event in events:

--- a/test/unit/test_randomai.gd
+++ b/test/unit/test_randomai.gd
@@ -76,7 +76,7 @@ func handle_discard_event(events, game : LocalGame, aiplayer : AIPlayer, gamepla
 	if game.game_state == Enums.GameState.GameState_DiscardDownToMax:
 		var event = get_event(events, Enums.EventType.EventType_HandSizeExceeded)
 		var discard_required_count = event['number']
-		var discard_action = aiplayer.pick_discard_to_max(game, gameplayer.my_id, discard_required_count)
+		var discard_action = aiplayer.pick_discard_to_max(discard_required_count)
 		assert_true(game.do_discard_to_max(gameplayer, discard_action.card_ids), "do discard failed")
 		events += game.get_latest_events()
 

--- a/test/unit/test_randomai.gd
+++ b/test/unit/test_randomai.gd
@@ -23,10 +23,8 @@ func game_setup(policy_type = AIPolicyRules):
 	game_logic.get_latest_events()
 	player1 = game_logic.player
 	player2 = game_logic.opponent
-	ai1 = AIPlayer.new()
-	ai1.initialize(game_logic, player1, policy_type.new())
-	ai2 = AIPlayer.new()
-	ai2.initialize(game_logic, player2, policy_type.new())
+	ai1 = AIPlayer.new(game_logic, player1, policy_type.new())
+	ai2 = AIPlayer.new(game_logic, player2, policy_type.new())
 
 func game_teardown():
 	# TODO: Move this logic into the real game so that it doesn't memory leak


### PR DESCRIPTION
AI(Game|Player|Strike)State are now Resources, so that it's easy to make manipulable copies. This is with an eye toward writing AI functionality that works with hypothetical scenarios.

The top level AIPlayer object now holds references to the actual game and player objects, so that most calls should refer to those objects directly instead of needing them passed in all the time. It's a bit of a stopgap -- what I'd really like most of the time is to be able to pass in a AIGameState and have functionality refer to that.

Unit tests pass, played through a full AI game or ten both within the Godot client and within a local HTML5 deployment, because apparently there are subtle differences in engine behavior. :neutral_face: