### PR TITLE
Save/Load replay files on browser & native + view hand in replays

### DIFF
--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -23,7 +23,21 @@ vram_texture_compression/for_desktop=true
 vram_texture_compression/for_mobile=false
 html/export_icon=true
 html/custom_html_shell=""
-html/head_include=""
+html/head_include="<script>
+//called in main_menu.gd for loading replays
+function setupFileLoad(callback){
+	window.input = document.createElement('input');
+	input.type = 'file';
+	input.onchange = e => {
+		var file = e.target.files[0];
+		var reader = new FileReader();
+		reader.readAsText(file, 'UTF-8');
+		reader.onload = readerEvent => {
+			callback(readerEvent.target.result);
+		}
+	}
+}
+</script>"
 html/canvas_resize_policy=2
 html/focus_canvas_on_start=true
 html/experimental_virtual_keyboard=true

--- a/scenes/game/combat_log.gd
+++ b/scenes/game/combat_log.gd
@@ -2,7 +2,6 @@ extends CenterContainer
 
 signal close_button_pressed
 signal filter_toggle_update
-signal replay_button_pressed
 
 const Enums = preload("res://scenes/game/enums.gd")
 
@@ -11,7 +10,6 @@ var DEFAULT_OPPONENT_COLOR = "#16c2f7"
 var DEFAULT_CARD_COLOR = "#7DF9FF"
 
 @onready var log_text = $PanelContainer/OuterMargin/VerticalLayout/LogText
-@onready var replay_button = $PanelContainer/OuterMargin/VerticalLayout/LogButtons/ReplayButton
 
 @onready var toggle_checkboxes = [
 	$PanelContainer/OuterMargin/VerticalLayout/LogFilters/Actions,
@@ -83,9 +81,6 @@ func get_filters():
 			filters.append(log_type)
 	return filters
 
-func set_replay_button_visibility(replay_visible : bool):
-	replay_button.visible = replay_visible
-
 func _on_log_filter_actions_toggle(state):
 	log_filter_toggles[Enums.LogType.LogType_Action] = state
 	GlobalSettings.set_combat_log_setting('filter_action', state)
@@ -124,9 +119,6 @@ func _on_copy_button_pressed():
 	#var current_clipboard = DisplayServer.clipboard_get()
 	# Set the contents of the clipboard
 	DisplayServer.clipboard_set(log_text.text)
-
-func _on_export_button_pressed():
-	replay_button_pressed.emit()
 
 func _on_player_color_changed(color):
 	log_player_color = "#%02x%02x%02x" % [color.r8, color.g8, color.b8]

--- a/scenes/game/combat_log.tscn
+++ b/scenes/game/combat_log.tscn
@@ -115,11 +115,6 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "Copy Log to Clipboard"
 
-[node name="ReplayButton" type="Button" parent="PanelContainer/OuterMargin/VerticalLayout/LogButtons"]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "Copy Replay to Clipboard"
-
 [node name="LogFilters" type="HBoxContainer" parent="PanelContainer/OuterMargin/VerticalLayout"]
 layout_mode = 2
 
@@ -183,7 +178,6 @@ edit_alpha = false
 [connection signal="pressed" from="CloseOuterClick" to="." method="_on_close_button_pressed"]
 [connection signal="pressed" from="PanelContainer/OuterMargin/VerticalLayout/CloseButton" to="." method="_on_close_button_pressed"]
 [connection signal="pressed" from="PanelContainer/OuterMargin/VerticalLayout/LogButtons/CopyButton" to="." method="_on_copy_button_pressed"]
-[connection signal="pressed" from="PanelContainer/OuterMargin/VerticalLayout/LogButtons/ReplayButton" to="." method="_on_export_button_pressed"]
 [connection signal="toggled" from="PanelContainer/OuterMargin/VerticalLayout/LogFilters/Actions" to="." method="_on_log_filter_actions_toggle"]
 [connection signal="toggled" from="PanelContainer/OuterMargin/VerticalLayout/LogFilters/CardInfo" to="." method="_on_log_filter_card_info_toggle"]
 [connection signal="toggled" from="PanelContainer/OuterMargin/VerticalLayout/LogFilters/Effects" to="." method="_on_log_filter_effects_toggle"]

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -5155,7 +5155,7 @@ func generate_replay_string():
 	var replay_log = {'messages': messages_list}
 	return JSON.stringify(replay_log)
 
-func replay_name():
+func get_replay_filename():
 	var filename = Time.get_datetime_string_from_system(false, true).substr(2, 14).replace(":","h")
 	filename = filename + " %s (%s) vs %s (%s).txt" % [
 		player_deck["id"],
@@ -5167,9 +5167,9 @@ func replay_name():
 func _on_save_replay_button_pressed():
 	if OS.has_feature("web"):
 		var replay_string = generate_replay_string()
-		JavaScriptBridge.download_buffer(replay_string.to_utf8_buffer(), replay_name(), "text/plain")
+		JavaScriptBridge.download_buffer(replay_string.to_utf8_buffer(), get_replay_filename(), "text/plain")
 	else:
-		file_dialog.current_file = replay_name()
+		file_dialog.current_file = get_replay_filename()
 		file_dialog.visible = true
 
 func _on_file_dialog_file_selected(path):

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -267,6 +267,7 @@ var starting_message = null
 var replay_button_visible = false
 var observer_mode = false
 var observer_live = false
+var replay_mode = false
 var exiting = false
 
 @onready var CenterCardOval = Vector2(get_viewport().content_scale_size) * Vector2(0.5, 1.35)
@@ -307,7 +308,7 @@ func _ready():
 
 	observer_next_button.visible = observer_mode
 	observer_play_to_live_button.visible = observer_mode
-	combat_log.set_replay_button_visibility(replay_button_visible)
+	combat_log.set_replay_button_visibility(false)
 
 	for i in range(1, 10):
 		player_lightningrod_tracking[i] = {
@@ -358,6 +359,7 @@ func begin_local_game(vs_info):
 func begin_remote_game(game_start_message):
 	starting_message = game_start_message.duplicate()
 	observer_mode = 'observer_mode' in game_start_message and game_start_message['observer_mode']
+	replay_mode = 'replay_mode' in game_start_message and game_start_message['replay_mode']
 	replay_button_visible = not observer_mode
 	# Add a few seconds to starting timers to account for loading screen
 	starting_timer = game_start_message['starting_timer'] + 4
@@ -409,6 +411,7 @@ func begin_remote_game(game_start_message):
 		starting_player,
 		seed_value,
 		observer_mode,
+		replay_mode,
 		starting_message_queue)
 
 func set_player_as_clock_user(player_id : Enums.PlayerId):
@@ -625,7 +628,7 @@ func spawn_deck(deck_id,
 		var logic_card : GameCard = card_db.get_card(card.id)
 		var image_path = get_card_image_path(deck_id, logic_card)
 		var new_card = create_card(card.id, logic_card.definition, image_path, card_back_image, deck_card_zone, is_opponent)
-		if observer_mode:
+		if observer_mode and not replay_mode:
 			new_card.skip_flip_when_drawing = true
 		if logic_card.set_aside:
 			reparent_to_zone(new_card, set_aside_zone)
@@ -2149,6 +2152,7 @@ func _on_force_wild_swing(event):
 func _on_game_over(event):
 	printlog("GAME OVER for %s" % game_wrapper.get_player_name(event['event_player']))
 	game_over_stuff.visible = true
+	combat_log.set_replay_button_visibility(replay_button_visible)
 	change_ui_state(UIState.UIState_GameOver, UISubState.UISubState_None)
 	_update_buttons()
 	var player = event['event_player']

--- a/scenes/game/game.tscn
+++ b/scenes/game/game.tscn
@@ -620,6 +620,12 @@ theme_override_font_sizes/font_size = 17
 text = "Combat
 Log"
 
+[node name="SaveReplayButton" type="Button" parent="PlayerZones"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 17
+text = "Save
+Replay"
+
 [node name="OpponentZones" type="VBoxContainer" parent="."]
 offset_left = 208.0
 offset_top = 8.0
@@ -842,6 +848,11 @@ offset_bottom = 720.0
 [node name="TurnStartAudio" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("27_aidi8")
 
+[node name="FileDialog" type="FileDialog" parent="."]
+initial_position = 1
+size = Vector2i(800, 400)
+access = 2
+
 [connection signal="pressed" from="ArenaNode/RowButtons/ArenaSquare1/Button" to="." method="_on_arena_location_pressed" binds= [1]]
 [connection signal="pressed" from="ArenaNode/RowButtons/ArenaSquare2/Button" to="." method="_on_arena_location_pressed" binds= [2]]
 [connection signal="pressed" from="ArenaNode/RowButtons/ArenaSquare3/Button" to="." method="_on_arena_location_pressed" binds= [3]]
@@ -860,6 +871,7 @@ stream = ExtResource("27_aidi8")
 [connection signal="gauge_clicked" from="PlayerZones/PlayerOverdrive" to="." method="_on_player_overdrive_gauge_clicked"]
 [connection signal="gauge_clicked" from="PlayerZones/PlayerSealed" to="." method="_on_player_sealed_clicked"]
 [connection signal="pressed" from="PlayerZones/CombatLogButton" to="." method="_on_combat_log_button_pressed"]
+[connection signal="pressed" from="PlayerZones/SaveReplayButton" to="." method="_on_save_replay_button_pressed"]
 [connection signal="gauge_clicked" from="OpponentZones/OpponentGauge" to="." method="_on_opponent_gauge_gauge_clicked"]
 [connection signal="gauge_clicked" from="OpponentZones/OpponentOverdrive" to="." method="_on_opponent_overdrive_gauge_clicked"]
 [connection signal="gauge_clicked" from="OpponentZones/OpponentSealed" to="." method="_on_opponent_sealed_clicked"]
@@ -879,7 +891,7 @@ stream = ExtResource("27_aidi8")
 [connection signal="pressed" from="EmoteButton" to="." method="_on_emote_button_pressed"]
 [connection signal="close_button_pressed" from="CombatLog" to="." method="_on_combat_log_close_button_pressed"]
 [connection signal="filter_toggle_update" from="CombatLog" to="." method="_on_combat_log_button_pressed"]
-[connection signal="replay_button_pressed" from="CombatLog" to="." method="_on_combat_log_replay_button_pressed"]
 [connection signal="close_button_pressed" from="EmoteDialog" to="." method="_on_emote_dialog_close_button_pressed"]
 [connection signal="emote_selected" from="EmoteDialog" to="." method="_on_emote_dialog_emote_selected"]
 [connection signal="accept_button_pressed" from="ModalDialog" to="." method="_on_modal_dialog_accept_button_pressed"]
+[connection signal="file_selected" from="FileDialog" to="." method="_on_file_dialog_file_selected"]

--- a/scenes/game/game_wrapper.gd
+++ b/scenes/game/game_wrapper.gd
@@ -50,6 +50,7 @@ func initialize_remote_game(player_info,
 		starting_player : Enums.PlayerId, 
 		seed_value : int, 
 		observer_mode : bool, 
+		replay_mode : bool, 
 		starting_message_queue : Array):
 	current_game = RemoteGame.new()
 	current_game.initialize_game(player_info, 
@@ -57,6 +58,7 @@ func initialize_remote_game(player_info,
 		starting_player, 
 		seed_value, 
 		observer_mode, 
+		replay_mode, 
 		starting_message_queue)
 
 # Deletes the current game

--- a/scenes/game/remote_game.gd
+++ b/scenes/game/remote_game.gd
@@ -19,6 +19,7 @@ var local_game : LocalGame
 var _player_info
 var _opponent_info
 var _observer_mode : bool
+var _replay_mode : bool
 var _game_message_queue : Array
 var _game_message_history : Array
 
@@ -54,6 +55,7 @@ func initialize_game(player_info,
 		starting_player : Enums.PlayerId, 
 		seed_value : int, 
 		observer_mode : bool, 
+		replay_mode : bool, 
 		starting_message_queue : Array):
 	_game_message_queue = starting_message_queue
 	_game_message_history = []
@@ -61,6 +63,7 @@ func initialize_game(player_info,
 	_player_info = player_info
 	_opponent_info = opponent_info
 	_observer_mode = observer_mode
+	_replay_mode = replay_mode
 	local_game = LocalGame.new()
 	local_game.initialize_game(player_info['deck'], opponent_info['deck'], 
 		player_info['name'], opponent_info['name'], starting_player, seed_value)
@@ -100,7 +103,8 @@ func _save_game_message(game_message):
 	_game_message_history.append(updated_game_message)
 
 func _on_disconnected():
-	local_game.do_quit(Enums.PlayerId.PlayerId_Player, Enums.GameOverReason.GameOverReason_Disconnect)
+	if not _replay_mode:
+		local_game.do_quit(Enums.PlayerId.PlayerId_Player, Enums.GameOverReason.GameOverReason_Disconnect)
 
 func _on_remote_player_quit(_is_disconnect : bool):
 	var reason = Enums.GameOverReason.GameOverReason_Quit

--- a/scenes/menu/main_menu.gd
+++ b/scenes/menu/main_menu.gd
@@ -452,8 +452,14 @@ func _on_settings_button_pressed():
 	settings_window.visible = true
 
 func load_replay(data):
-	var replay_data = JSON.parse_string(data[0])
-	_on_observe_game_started(replay_data, true)
+	var json = JSON.new()
+	if json.parse(data[0]) == OK:
+		var replay_data = json.data
+		_on_observe_game_started(replay_data, true)
+	else:
+		var error_message = "JSON Parse Error: " + json.get_error_message()
+		modal_dialog.set_text_fields(error_message, "OK", "")
+		update_buttons(false)
 
 func _on_file_dialog_file_selected(path):
 	load_replay([FileAccess.get_file_as_string(path)])

--- a/scenes/menu/main_menu.gd
+++ b/scenes/menu/main_menu.gd
@@ -9,13 +9,16 @@ const PlayerNameMaxLen = 12
 const ModalList = preload("res://scenes/menu/modal_list.gd")
 const ModalDialog = preload("res://scenes/game/modal_dialog.gd")
 
+#These only get set and used if run on web
+var window
+var file_load_callback
+
 @onready var player_list : ItemList = $PlayerList
 @onready var player_selected_character : String = "solbadguy"
 @onready var opponent_selected_character : String = "kykisuke"
 @onready var selecting_player : bool = true
 
 @onready var player_name_box : TextEdit = $PlayerNameBox
-@onready var replay_data_box : TextEdit = $EnterReplayBox
 
 @onready var start_ai_button : Button = $MenuList/VSAIBox/StartButton
 @onready var room_select : LineEdit = $MenuList/JoinBox/RoomNameBox
@@ -24,6 +27,7 @@ const ModalDialog = preload("res://scenes/game/modal_dialog.gd")
 @onready var matchmake_button = $MenuList/MatchmakeButton
 @onready var settings_button = $SettingsButton
 @onready var settings_window = $PreferencesWindow
+@onready var file_dialog = $FileDialog
 
 @onready var char_select = $CharSelect
 @onready var change_player_character_button : Button = $PlayerChooser/ChangePlayerCharacterButton
@@ -64,10 +68,18 @@ func _ready():
 	_on_char_select_select_character(opponent_selected_character)
 	modal_dialog.visible = false
 	modal_list.visible = false
+	file_dialog.visible = false
 
 	# Initialize settings window
 	settings_window.visible = false
 	settings_window.bgm_check_toggled.connect(_on_bgm_check_toggled)
+
+	if OS.has_feature("web"):
+		#setupFileLoad defined in the HTML5 export header
+		#calls load_replay when file gets user-selected by window.input.click()
+		window = JavaScriptBridge.get_interface("window")
+		file_load_callback = JavaScriptBridge.create_callback(load_replay)
+		window.setupFileLoad(file_load_callback)
 
 func settings_loaded():
 	player_selected_character = GlobalSettings.PlayerCharacter if GlobalSettings.PlayerCharacter else "solbadguy"
@@ -94,6 +106,8 @@ func returned_from_game():
 	update_buttons(false)
 	just_clicked_matchmake = false
 	start_music()
+	if OS.has_feature("web"):
+		window.setupFileLoad(file_load_callback)
 
 func _on_start_button_pressed():
 	# For local play, random selection is still random at this point.
@@ -393,9 +407,6 @@ func _on_player_name_box_focus_entered():
 func _on_player_name_box_text_changed():
 	cropLineToMaxLength_name_text_edit(player_name_box.text, PlayerNameMaxLen)
 
-func _on_enter_replay_box_focus_entered():
-	replay_data_box.select_all()
-
 func _on_players_button_pressed():
 	modal_list.show_player_list()
 
@@ -431,11 +442,18 @@ func _on_modal_list_observe_match_pressed(row_index):
 	NetworkManager.observe_room(player_name, room_name)
 	update_buttons(true)
 
-func _on_view_replay_button_pressed():
-	if replay_data_box.text:
-		var replay_data = JSON.parse_string(replay_data_box.text)
-		_on_observe_game_started(replay_data, true)
+func _on_load_replay_button_pressed():
+	if OS.has_feature("web"):
+		window.input.click()
+	else:
+		file_dialog.visible = true
 
 func _on_settings_button_pressed():
 	settings_window.visible = true
 
+func load_replay(data):
+	var replay_data = JSON.parse_string(data[0])
+	_on_observe_game_started(replay_data, true)
+
+func _on_file_dialog_file_selected(path):
+	load_replay([FileAccess.get_file_as_string(path)])

--- a/scenes/menu/main_menu.gd
+++ b/scenes/menu/main_menu.gd
@@ -168,7 +168,7 @@ func get_deck_id_without_random_tag(deck_id):
 		return deck_id.split("#")[1]
 	return deck_id
 
-func _on_observe_game_started(data):
+func _on_observe_game_started(data, is_replay = false):
 	just_clicked_matchmake = false
 
 	# Observe games pass in the full message log up to this point.
@@ -192,6 +192,7 @@ func _on_observe_game_started(data):
 	start_data['player2_deck_id'] = opponent_deck_no_random
 
 	start_data['observer_mode'] = true
+	start_data['replay_mode'] = is_replay
 	start_data['observer_log'] = message_log.slice(1)
 
 	var player_deck_object = CardDefinitions.get_deck_from_str_id(player_deck_no_random)
@@ -433,7 +434,7 @@ func _on_modal_list_observe_match_pressed(row_index):
 func _on_view_replay_button_pressed():
 	if replay_data_box.text:
 		var replay_data = JSON.parse_string(replay_data_box.text)
-		_on_observe_game_started(replay_data)
+		_on_observe_game_started(replay_data, true)
 
 func _on_settings_button_pressed():
 	settings_window.visible = true

--- a/scenes/menu/main_menu.tscn
+++ b/scenes/menu/main_menu.tscn
@@ -250,24 +250,14 @@ offset_bottom = 243.0
 theme_override_font_sizes/font_size = 32
 text = "Update Name"
 
-[node name="EnterReplayBox" type="TextEdit" parent="."]
-custom_minimum_size = Vector2(100, 50)
-layout_mode = 0
-offset_left = 16.0
-offset_top = 440.0
-offset_right = 320.0
-offset_bottom = 501.0
-theme_override_font_sizes/font_size = 34
-placeholder_text = "Replay Code"
-
-[node name="ViewReplayButton" type="Button" parent="."]
+[node name="LoadReplayButton" type="Button" parent="."]
 layout_mode = 0
 offset_left = 16.0
 offset_top = 520.0
 offset_right = 320.0
 offset_bottom = 573.0
 theme_override_font_sizes/font_size = 32
-text = "View Replay"
+text = "Load Replay"
 
 [node name="PlayerList" type="ItemList" parent="."]
 layout_mode = 0
@@ -416,6 +406,14 @@ text = "##"
 [node name="PreferencesWindow" parent="." instance=ExtResource("12_7sva6")]
 visible = false
 
+[node name="FileDialog" type="FileDialog" parent="."]
+title = "Open a File"
+initial_position = 1
+size = Vector2i(800, 400)
+ok_button_text = "Open"
+file_mode = 0
+access = 2
+
 [connection signal="pressed" from="SettingsButton" to="." method="_on_settings_button_pressed"]
 [connection signal="pressed" from="MenuList/VSAIBox/StartButton" to="." method="_on_start_button_pressed"]
 [connection signal="pressed" from="MenuList/VSAIBox/OpponentChooser/ChangePlayerCharacterButton" to="." method="_on_change_player_character_button_pressed" binds= [false]]
@@ -428,8 +426,7 @@ visible = false
 [connection signal="focus_entered" from="PlayerNameBox" to="." method="_on_player_name_box_focus_entered"]
 [connection signal="text_changed" from="PlayerNameBox" to="." method="_on_player_name_box_text_changed"]
 [connection signal="pressed" from="UpdateNameButton" to="." method="_on_update_name_button_pressed"]
-[connection signal="focus_entered" from="EnterReplayBox" to="." method="_on_enter_replay_box_focus_entered"]
-[connection signal="pressed" from="ViewReplayButton" to="." method="_on_view_replay_button_pressed"]
+[connection signal="pressed" from="LoadReplayButton" to="." method="_on_load_replay_button_pressed"]
 [connection signal="pressed" from="ReconnectToServerButton" to="." method="_on_reconnect_to_server_button_pressed"]
 [connection signal="close_character_select" from="CharSelect" to="." method="_on_char_select_close_character_select"]
 [connection signal="select_character" from="CharSelect" to="." method="_on_char_select_select_character"]
@@ -437,3 +434,4 @@ visible = false
 [connection signal="pressed" from="RoomListContainer/RoomListHBox/MatchesButton" to="." method="_on_matches_button_pressed"]
 [connection signal="join_match_pressed" from="ModalList" to="." method="_on_modal_list_join_match_pressed"]
 [connection signal="observe_match_pressed" from="ModalList" to="." method="_on_modal_list_observe_match_pressed"]
+[connection signal="file_selected" from="FileDialog" to="." method="_on_file_dialog_file_selected"]


### PR DESCRIPTION
"Save Replay" button appears below "Combat Log" button at game end, downloads in browser and opens a file saving dialog in native. Filename defaults to "YY-MM-DD HHhMM ryu (nick) vs ken (nick).txt", folder in native defaults to where the exe is.
"Load Replay" button in main menu prompts for a file, compatible with files made from the previous clipboard implementation.
Your hand is now visible in replays, since it makes them much more useful for game review. Saving replays should not be made possible before the game is over, since it's trivial to edit the file to flip the POV.