### PR TITLE
Hotfix on Justice in Spades! boost

### DIFF
--- a/data/card_definitions.json
+++ b/data/card_definitions.json
@@ -26770,7 +26770,7 @@
 					}
 				},
 				{
-					"timing": "now",
+					"timing": "end_of_turn",
 					"effect_type": "discard_continuous_boost",
 					"required": true,
 					"limitation": "mine",
@@ -26778,7 +26778,8 @@
 					"and": {
 						"effect_type": "draw",
 						"amount": 1
-					}
+					},
+					"override_description": "Now: Discard a Continuous Boost, then Draw 1"
 				}
 			]
 		}


### PR DESCRIPTION
Changed timing to end_of_turn so that Justice in Spades itself can be discarded, added an override_description so that it still describes itself as a Now effect.