### PR TITLE
Fix lightning rod corner cases

### DIFF
--- a/scenes/core/local_game.gd
+++ b/scenes/core/local_game.gd
@@ -2588,7 +2588,7 @@ func handle_strike_effect(card_id : int, effect, performing_player : Player):
 			var crit_name = "Critical"
 			if 'alt_crit_name' in effect:
 				crit_name = effect['alt_crit_name']
-			
+
 			performing_player.strike_stat_boosts.critical = true
 			_append_log_full(Enums.LogType.LogType_Effect, performing_player, "'s strike is %s!" % crit_name)
 			var strike_card = active_strike.get_player_card(performing_player)
@@ -3496,7 +3496,7 @@ func handle_strike_effect(card_id : int, effect, performing_player : Player):
 			var target_range = effect['target_range']
 			if target_range is String and target_range == "range_from_opponent":
 				target_range = opposing_player.distance_to_opponent()
-			
+
 			var range_name_str = target_range
 			if not target_range is String:
 				range_name_str = "Range %s" % target_range
@@ -4030,11 +4030,16 @@ func handle_strike_effect(card_id : int, effect, performing_player : Player):
 
 						# Include the next available space closest to the opponent.
 						# Loop from i towards the player.
-						for test_location in range(i, performing_player.arena_location, direction):
-							if performing_player.can_move_to(test_location, true):
+						# The player's current space should be usable if they're adjacent to the opponent.
+						for test_location in range(i, performing_player.arena_location + direction, direction):
+							if performing_player.is_overlapping_opponent(test_location):
+								continue
+							if performing_player.can_move_to(test_location, true) or test_location == performing_player.arena_location:
+								if performing_player.cannot_move:
+									break
 								if test_location not in valid_locations:
 									valid_locations.append(test_location)
-									break
+								break
 
 			if len(valid_locations) > 0:
 				# Let the player choose where to go.
@@ -6372,13 +6377,13 @@ func do_queued_effects(performing_player : Player):
 		var effect = queued_effect_chain["effect"]
 		var chain = queued_effect_chain["chain"]
 		var local_conditions = queued_effect_chain["local_conditions"]
-		
+
 		var after_resolution = false
 		if 'after_resolution' in effect:
 			after_resolution = effect['after_resolution']
 		if after_resolution and resolving_boost_before_queue:
 			break
-		
+
 		if chain:
 			queued_effect_chain = chain
 		else:
@@ -6976,13 +6981,13 @@ func get_gauge_cost(performing_player : Player, card, check_if_card_in_hand = fa
 				gauge_cost = range_to_opponent
 
 	return gauge_cost
-	
-	
+
+
 func get_force_cost(performing_player : Player, card):
 	var force_cost = card.definition['force_cost']
 	if 'force_cost_crit' in card.definition and performing_player.strike_stat_boosts.critical:
 		force_cost = card.definition['force_cost_crit']
-		
+
 	return force_cost
 
 func get_alternative_life_cost(performing_player : Player, card):
@@ -7791,7 +7796,7 @@ func continue_resolve_boost():
 				break
 
 			active_boost.effects_resolved += 1
-			
+
 		elif active_boost.effects_resolved < len(effects) + len(character_effects) + 1:
 			# After all effects are resolved, discard/move the card then check for cancel.
 			boost_finish_resolving_card(active_boost.playing_player)
@@ -7811,7 +7816,7 @@ func continue_resolve_boost():
 				do_queued_effects(active_boost.playing_player)
 			if game_state == Enums.GameState.GameState_PlayerDecision:
 				break
-				
+
 			boost_play_cleanup(active_boost.playing_player)
 			break
 
@@ -7879,7 +7884,7 @@ func boost_play_cleanup(performing_player : Player):
 		active_boost.effects_resolved += 1
 		continue_resolve_boost()
 		return
-		
+
 	if active_boost.queued_boosts:
 		var next_boost_id = active_boost.queued_boosts.pop_front()
 		begin_resolve_boost(performing_player, next_boost_id, [], active_boost.shuffle_discard_on_cleanup, true)
@@ -7919,7 +7924,7 @@ func boost_play_cleanup(performing_player : Player):
 				change_game_state(Enums.GameState.GameState_PickAction)
 				performing_player.next_strike_faceup = true
 				do_strike(performing_player, card.id, false, -1)
-				
+
 				#change_game_state(Enums.GameState.GameState_AutoStrike)
 				#decision_info.type = Enums.DecisionType.DecisionType_StrikeNow
 				#decision_info.player = performing_player.my_id
@@ -9510,7 +9515,7 @@ func do_force_for_effect(performing_player : Player, card_ids : Array, treat_ult
 		else:
 			_append_log_full(Enums.LogType.LogType_CardInfo, performing_player, "generates force by discarding %s." % _log_card_name(card_names))
 			performing_player.discard(card_ids)
-			
+
 		for i in range(0, effect_times):
 			handle_strike_effect(decision_info.choice_card_id, decision_effect, performing_player)
 

--- a/test/unit/test_rachel.gd
+++ b/test/unit/test_rachel.gd
@@ -658,3 +658,121 @@ func test_rachel_lightningrod_stuns_even_when_at_1():
 	validate_life(player1, 30, player2, 1)
 	assert_eq(player1.hand[-1].id, discard_id)
 	advance_turn(player1)
+
+func test_rachel_badenbadenlily_with_adjacent_rods():
+	position_players(player1, 3, player2, 8)
+	player1.discard_hand()
+
+	# First turn: boost spikedrop to place rod at position 7
+	give_player_specific_card(player1, "rachel_spikedrop", TestCardId1)
+	assert_true(game_logic.do_boost(player1, TestCardId1))
+	var discard_id1 = player1.discards[0].id
+	assert_true(game_logic.do_choose_from_discard(player1, [discard_id1]))
+	assert_true(game_logic.do_choice(player1, get_choice_index_for_position(7)))
+	assert_eq(player1.lightningrod_zones[6].size(), 1)
+	advance_turn(player2)
+
+	# Second turn: boost spikedrop to place rod at position 8
+	give_player_specific_card(player1, "rachel_spikedrop", TestCardId2)
+	assert_true(game_logic.do_boost(player1, TestCardId2))
+	var discard_id2 = player1.discards[0].id
+	assert_true(game_logic.do_choose_from_discard(player1, [discard_id2]))
+	assert_true(game_logic.do_choice(player1, get_choice_index_for_position(8)))
+	assert_eq(player1.lightningrod_zones[7].size(), 1)
+	advance_turn(player2)
+
+	# Third turn: boost Baden Baden Lily and verify only position 7 is available
+	# (Position 8 has opponent, so can't move there)
+	give_player_specific_card(player1, "rachel_badenbadenlily", TestCardId3)
+	give_player_specific_card(player1, "rachel_badenbadenlily", TestCardId4)
+	assert_true(game_logic.do_boost(player1, TestCardId3, [TestCardId4]))
+
+	# Verify only position 7 is offered as a valid choice
+	assert_eq(game_logic.decision_info.limitation.size(), 1)
+	assert_true(7 in game_logic.decision_info.limitation)
+	assert_false(6 in game_logic.decision_info.limitation)
+	assert_false(8 in game_logic.decision_info.limitation)
+
+	assert_true(game_logic.do_choice(player1, get_choice_index_for_position(7)))
+	validate_positions(player1, 7, player2, 8)
+	advance_turn(player1)
+
+func test_rachel_badenbadenlily_vs_exceeded_tinker_on_rod():
+	default_game_setup("tinker")
+	position_players(player1, 3, player2, 7)
+	player1.discard_hand()
+
+	# Turn into tank
+	give_gauge(player2, 5)
+	player2.life = 1
+	execute_strike(player1, player2, "standard_normal_dive", "standard_normal_grasp", [], [], false, false)
+
+	assert_eq(player2.extra_width, 1)
+	advance_turn(player2)
+
+	# Place a lightning rod at position 7 (where tinker will be after exceeding)
+	give_player_specific_card(player1, "rachel_spikedrop", TestCardId5)
+	assert_true(game_logic.do_boost(player1, TestCardId5))
+	var discard_id1 = player1.discards[0].id
+	assert_true(game_logic.do_choose_from_discard(player1, [discard_id1]))
+	assert_true(game_logic.do_choice(player1, get_choice_index_for_position(7)))
+	assert_eq(player1.lightningrod_zones[6].size(), 1)
+	advance_turn(player2)
+
+	# Now boost Baden Baden Lily - should only offer position 5
+	# (can't move to 7 because opponent is there, so finds closest space toward player)
+	give_player_specific_card(player1, "rachel_badenbadenlily", TestCardId3)
+	give_player_specific_card(player1, "rachel_badenbadenlily", TestCardId4)
+	assert_true(game_logic.do_boost(player1, TestCardId3, [TestCardId4]))
+
+	# Verify only position 5 is offered as valid
+	# (Position 7 has opponent, position 6 has no rod, position 5 is nearest valid space)
+	assert_eq(game_logic.decision_info.limitation.size(), 1)
+	assert_true(5 in game_logic.decision_info.limitation)
+	assert_false(6 in game_logic.decision_info.limitation)
+	assert_false(7 in game_logic.decision_info.limitation)
+
+	assert_true(game_logic.do_choice(player1, get_choice_index_for_position(5)))
+	validate_positions(player1, 5, player2, 7)
+	advance_turn(player1)
+
+
+func test_rachel_badenbadenlily_alt_rod_scenario():
+	position_players(player1, 4, player2, 5)
+	player1.discard_hand()
+
+	# First turn: boost spikedrop to place rod at position 5
+	give_player_specific_card(player1, "rachel_spikedrop", TestCardId1)
+	assert_true(game_logic.do_boost(player1, TestCardId1))
+	var discard_id1 = player1.discards[0].id
+	assert_true(game_logic.do_choose_from_discard(player1, [discard_id1]))
+	assert_true(game_logic.do_choice(player1, get_choice_index_for_position(5)))
+	assert_eq(player1.lightningrod_zones[4].size(), 1)
+	advance_turn(player2)
+
+	# Second turn: boost spikedrop to place rod at position 8
+	give_player_specific_card(player1, "rachel_spikedrop", TestCardId2)
+	assert_true(game_logic.do_boost(player1, TestCardId2))
+	var discard_id2 = player1.discards[0].id
+	assert_true(game_logic.do_choose_from_discard(player1, [discard_id2]))
+	assert_true(game_logic.do_choice(player1, get_choice_index_for_position(8)))
+	assert_eq(player1.lightningrod_zones[7].size(), 1)
+	advance_turn(player2)
+
+	# Third turn: boost Baden Baden Lily and verify only position 4 and 8 are available.
+	# (Position 5 has opponent so it should be treated as a close and position 4 should be available (p1 current location)
+	give_player_specific_card(player1, "rachel_badenbadenlily", TestCardId3)
+	give_player_specific_card(player1, "rachel_badenbadenlily", TestCardId4)
+	assert_true(game_logic.do_boost(player1, TestCardId3, [TestCardId4]))
+
+	# Verify only position 4 and 8 is offered as a valid choice
+	assert_eq(game_logic.decision_info.limitation.size(), 2)
+	assert_true(4 in game_logic.decision_info.limitation)
+	assert_true(8 in game_logic.decision_info.limitation)
+	assert_false(3 in game_logic.decision_info.limitation)
+	assert_false(5 in game_logic.decision_info.limitation)
+	assert_false(6 in game_logic.decision_info.limitation)
+
+	assert_true(game_logic.do_choice(player1, get_choice_index_for_position(4)))
+	validate_positions(player1, 4, player2, 5)
+	advance_turn(player1)


### PR DESCRIPTION
There was a bug with lightning rod when on the opponent, it could extend the valid positions too far for baden lily boost.

I also think tinker tank lightning rods were broken, so I addressed that and added a test.