### PR TITLE
Fix Treasure and Zsolt free force handling

### DIFF
--- a/globals/global_settings.gd
+++ b/globals/global_settings.gd
@@ -5,7 +5,7 @@ signal settings_loaded
 const ReleaseLoggingEnabled = false # If true, log even on release builds.
 const UseAzureServerAlways = true # If true, always defaults to the azure server.
 var MuteEmotes = false
-const ClientVersionString : String = "260712.2300" # YYMMDD.HHMM
+const ClientVersionString : String = "260717.2300" # YYMMDD.HHMM
 const ReplayVersion : int = 1
 
 const CharacterBanlist = ['carmine']

--- a/scenes/core/ai_player.gd
+++ b/scenes/core/ai_player.gd
@@ -392,7 +392,7 @@ func get_prepare_actions():
 func get_move_actions():
 	var possible_move_actions = []
 	var available_force = game_player.get_available_force()
-	var free_force_available = game_player.free_force
+	var free_force_available = game_player.get_available_free_force()
 	if game_player.cannot_move:
 		return possible_move_actions
 
@@ -472,7 +472,7 @@ func get_change_cards_actions():
 	var possible_actions = []
 	var total_change_card_options = len(game_player.hand) + len(game_player.gauge)
 	possible_actions.append(ChangeCardsAction.new([], false))
-	var free_force_available = game_player.free_force
+	var free_force_available = game_player.get_available_free_force()
 	if free_force_available > 0:
 		possible_actions.append(ChangeCardsAction.new([], true))
 
@@ -579,7 +579,7 @@ func get_boost_actions(valid_zones : Array, limitation : String, ignore_costs : 
 		"extra": game_player.set_aside_cards,
 		"deck": game_player.deck
 	}
-	var free_force_available = game_player.free_force
+	var free_force_available = game_player.get_available_free_force()
 
 	var multiple_boost_options = []
 	for zone in valid_zones:
@@ -720,7 +720,7 @@ func get_strike_actions(alternate_source : String = "", disable_wild_swing : boo
 
 func get_character_action_actions():
 	var possible_actions = []
-	var free_force_available = game_player.free_force
+	var free_force_available = game_player.get_available_free_force()
 	for action_idx in range(game_player.get_character_action_count()):
 		if game_player.can_do_character_action(action_idx):
 			var action = game_player.get_character_action(action_idx)
@@ -764,7 +764,7 @@ func determine_pay_strike_force_cost_actions(force_cost : int, wild_swing_allowe
 		possible_actions.append(PayStrikeCostAction.new([], true, false))
 
 	var all_force_option_ids = []
-	var free_force_available = game_player.free_force
+	var free_force_available = game_player.get_available_free_force()
 	for card in game_player.hand:
 		all_force_option_ids.append(card.id)
 	for card in game_player.gauge:
@@ -831,7 +831,7 @@ func determine_force_for_armor_actions():
 		# Considering every possible option takes way too long.
 		# You're never going to need more than +8 armor AI.
 		available_force = 4
-	var free_force_available = game_player.free_force
+	var free_force_available = game_player.get_available_free_force()
 	var all_force_option_ids = []
 
 	for card in game_player.hand:
@@ -850,7 +850,7 @@ func determine_force_for_armor_actions():
 func determine_force_for_effect_actions(options : Array):
 	var possible_actions = []
 	var available_force = game_player.get_available_force()
-	var free_force_available = game_player.free_force
+	var free_force_available = game_player.get_available_free_force()
 	var all_force_option_ids = []
 	for card in game_player.hand:
 		all_force_option_ids.append(card.id)

--- a/scenes/core/local_game.gd
+++ b/scenes/core/local_game.gd
@@ -7656,21 +7656,18 @@ func continue_resolve_strike():
 					var ea_card = deferred["card"]
 					var ea_player = deferred["player"]
 					var ea_hit = deferred["hit"]
+					var ea_transform = deferred["transform"]
+					var ea_always_to_gauge = deferred["always_to_gauge"]
 					if ea_card not in active_strike.cards_in_play:
 						continue
-					# Only allow transform for cards with transform boost
-					var ea_transform = false
-					if ea_card.definition.get("boost", {}).get("boost_type") == "transform":
-						ea_transform = active_strike.extra_attack_data.zsolt_extra_transform \
-								or ea_player.strike_stat_boosts.move_strike_to_transforms
 					if ea_transform:
 						_append_log_full(Enums.LogType.LogType_CardInfo, ea_player, "transforms extra attack %s." % _log_card_name(ea_card.definition['display_name']))
 						if not ea_player.add_to_transforms(ea_card):
-							if ea_hit or active_strike.extra_attack_data.extra_attack_always_go_to_gauge:
+							if ea_hit or ea_always_to_gauge:
 								ea_player.add_to_gauge(ea_card)
 							else:
 								ea_player.add_to_discards(ea_card)
-					elif ea_hit or active_strike.extra_attack_data.extra_attack_always_go_to_gauge:
+					elif ea_hit or ea_always_to_gauge:
 						ea_player.add_to_gauge(ea_card)
 					else:
 						ea_player.add_to_discards(ea_card)
@@ -7990,7 +7987,11 @@ func continue_extra_attack():
 					var deferred_entry = {
 						"card": attacker_card,
 						"player": attacker_player,
-						"hit": active_strike.extra_attack_data.extra_attack_hit
+						"hit": active_strike.extra_attack_data.extra_attack_hit,
+						"transform": attacker_card.definition.get("boost", {}).get("boost_type") == "transform" \
+								and (active_strike.extra_attack_data.zsolt_extra_transform \
+								or attacker_player.strike_stat_boosts.move_strike_to_transforms),
+						"always_to_gauge": active_strike.extra_attack_data.extra_attack_always_go_to_gauge
 					}
 					active_strike.deferred_extra_attack_cards.append(deferred_entry)
 				else:

--- a/scenes/core/player.gd
+++ b/scenes/core/player.gd
@@ -1649,7 +1649,7 @@ func play_replacement_boosts(card_ids : Array, replacement_boost):
 func get_force_with_cards(card_ids : Array, reason : String, treat_ultras_as_single_force : bool, use_free_force : bool):
 	var force_generated = force_cost_reduction
 	if use_free_force:
-		force_generated += free_force
+		force_generated += get_free_force_for_payment()
 		if reason == "CHANGE_CARDS":
 			force_generated += free_force_cc_only
 
@@ -2495,13 +2495,19 @@ func add_to_top_of_deck(card : GameCard, public : bool):
 	return [parent.create_event(Enums.EventType.EventType_AddToDeck, my_id, card.id)]
 
 func get_available_force():
-	var force = force_cost_reduction + free_force
+	var force = force_cost_reduction + get_available_free_force()
 	for card in hand:
 		force += card_database.get_card_force_value(card.id)
 	for card in gauge:
 		force += card_database.get_card_force_value(card.id)
 	force += get_force_from_spent_life(life)
 	return force
+
+func get_available_free_force():
+	return max(free_force, zsolt_force_pool)
+
+func get_free_force_for_payment():
+	return free_force if free_force > 0 else zsolt_force_pool
 
 func get_available_gauge():
 	var available_gauge = free_gauge
@@ -3013,17 +3019,19 @@ func disable_boost_effects(card : GameCard, buddy_ignore_condition : bool = fals
 					if force_cost_reduction == 0:
 						parent._append_log_full(Enums.LogType.LogType_Effect, self, "no longer has their force costs reduced.")
 				StrikeEffects.GenerateFreeForce:
-					free_force -= effect['amount']
-					if free_force < 0:
-						free_force = 0
-					if free_force == 0:
-						parent._append_log_full(Enums.LogType.LogType_Effect, self, "no longer generates free force.")
 					if effect.get('zsolt_force_pool', false):
 						zsolt_force_pool -= effect['amount']
 						if zsolt_force_pool < 0:
 							zsolt_force_pool = 0
+						free_force = 0
 						if zsolt_force_pool == 0:
+							parent._append_log_full(Enums.LogType.LogType_Effect, self, "no longer generates free force.")
+					else:
+						free_force -= effect['amount']
+						if free_force < 0:
 							free_force = 0
+						if free_force == 0:
+							parent._append_log_full(Enums.LogType.LogType_Effect, self, "no longer generates free force.")
 				StrikeEffects.GaugeCostsReducedPassive:
 					free_gauge -= effect['amount']
 					if free_gauge < 0:
@@ -3147,8 +3155,6 @@ func _recalc_zsolt_pool():
 			if effect.get('zsolt_force_pool', false):
 				new_pool += effect['amount']
 	zsolt_force_pool = new_pool
-	if zsolt_force_pool == 0:
-		free_force = 0
 
 func get_all_non_immediate_continuous_boost_effects():
 	var effects = []

--- a/scenes/core/remote_game.gd
+++ b/scenes/core/remote_game.gd
@@ -49,6 +49,15 @@ func _get_player_from_remote_id(remote_id : int):
 	else:
 		return _get_player(Enums.PlayerId.PlayerId_Opponent)
 
+func _get_zsolt_free_force_amount(player : Player, use_free_force : bool) -> int:
+	if use_free_force and player.zsolt_force_pool > 0:
+		return player.get_free_force_for_payment()
+	return 0
+
+func _apply_zsolt_free_force_amount(player : Player, action_message) -> void:
+	if player.zsolt_force_pool > 0 and action_message.has('zsolt_free_force_amount'):
+		player.free_force = action_message['zsolt_free_force_amount']
+
 func get_striking_card_ids_for_player(player : Player) -> Array:
 	return local_game.get_striking_card_ids_for_player(player)
 
@@ -275,6 +284,7 @@ func do_pay_strike_cost(
 		'wild_strike': wild_strike,
 		'discard_ex_first': discard_ex_first,
 		'use_free_force': use_free_force,
+		'zsolt_free_force_amount': _get_zsolt_free_force_amount(player, use_free_force),
 		'spent_life_for_force': spent_life_for_force,
 		'pay_alternative_life_cost': pay_alternative_life_cost,
 		'spent_life_for_gauge': spent_life_for_gauge
@@ -288,6 +298,7 @@ func process_pay_strike_cost(action_message) -> void:
 	var wild_strike = action_message['wild_strike']
 	var discard_ex_first = action_message['discard_ex_first']
 	var use_free_force = action_message['use_free_force']
+	_apply_zsolt_free_force_amount(game_player, action_message)
 	var spent_life_for_force = action_message['spent_life_for_force']
 	var pay_alternative_life_cost = action_message['pay_alternative_life_cost']
 	var spent_life_for_gauge = action_message.get('spent_life_for_gauge', 0)
@@ -316,6 +327,7 @@ func do_move(player : Player, card_ids : Array, new_arena_location : int, use_fr
 		'card_ids': card_ids,
 		'new_arena_location': new_arena_location,
 		'use_free_force': use_free_force,
+		'zsolt_free_force_amount': _get_zsolt_free_force_amount(player, use_free_force),
 		'spent_life_for_force': spent_life_for_force,
 	}
 	_submit_game_message(action_message)
@@ -326,6 +338,7 @@ func process_move(action_message) -> void:
 	var card_ids = action_message['card_ids']
 	var new_arena_location = action_message['new_arena_location']
 	var use_free_force = action_message['use_free_force']
+	_apply_zsolt_free_force_amount(game_player, action_message)
 	var spent_life_for_force = action_message['spent_life_for_force']
 	local_game.do_move(game_player, card_ids, new_arena_location, use_free_force, spent_life_for_force)
 
@@ -337,6 +350,7 @@ func do_change(player : Player, card_ids : Array, treat_ultras_as_single_force :
 		'card_ids': card_ids,
 		'treat_ultras_as_single_force': treat_ultras_as_single_force,
 		'use_free_force': use_free_force,
+		'zsolt_free_force_amount': _get_zsolt_free_force_amount(player, use_free_force),
 		'spent_life_for_force': spent_life_for_force,
 	}
 	_submit_game_message(action_message)
@@ -347,6 +361,7 @@ func process_change(action_message) -> void:
 	var card_ids = action_message['card_ids']
 	var treat_ultras_as_single_force = action_message['treat_ultras_as_single_force']
 	var use_free_force = action_message['use_free_force']
+	_apply_zsolt_free_force_amount(game_player, action_message)
 	var spent_life_for_force = action_message['spent_life_for_force']
 	local_game.do_change(game_player, card_ids, treat_ultras_as_single_force, use_free_force, spent_life_for_force)
 
@@ -379,6 +394,7 @@ func do_force_for_armor(player : Player, card_ids : Array, use_free_force : bool
 		'player_id': _get_player_remote_id(player),
 		'card_ids': card_ids,
 		'use_free_force': use_free_force,
+		'zsolt_free_force_amount': _get_zsolt_free_force_amount(player, use_free_force),
 		'spent_life_for_force': spent_life_for_force,
 	}
 	_submit_game_message(action_message)
@@ -388,6 +404,7 @@ func process_force_for_armor(action_message) -> void:
 	var game_player = _get_player_from_remote_id(action_message['player_id'])
 	var card_ids = action_message['card_ids']
 	var use_free_force = action_message['use_free_force']
+	_apply_zsolt_free_force_amount(game_player, action_message)
 	var spent_life_for_force = action_message['spent_life_for_force']
 	local_game.do_force_for_armor(game_player, card_ids, use_free_force, spent_life_for_force)
 
@@ -413,6 +430,7 @@ func do_boost(player : Player, card_id : int, payment_card_ids = [],
 		'card_id': card_id,
 		'payment_card_ids': payment_card_ids,
 		'use_free_force': use_free_force,
+		'zsolt_free_force_amount': _get_zsolt_free_force_amount(player, use_free_force),
 		'spent_life_for_force': spent_life_for_force,
 		'additional_boost_ids': additional_boost_ids
 	}
@@ -424,6 +442,7 @@ func process_boost(action_message) -> void:
 	var card_id = action_message['card_id']
 	var payment_card_ids = action_message['payment_card_ids']
 	var use_free_force = action_message['use_free_force']
+	_apply_zsolt_free_force_amount(game_player, action_message)
 	var spent_life_for_force = action_message['spent_life_for_force']
 	var additional_boost_ids = action_message['additional_boost_ids']
 	local_game.do_boost(game_player, card_id, payment_card_ids, use_free_force, spent_life_for_force, additional_boost_ids)
@@ -465,6 +484,7 @@ func do_force_for_effect(player : Player, card_ids : Array, treat_ultras_as_sing
 		'treat_ultras_as_single_force': treat_ultras_as_single_force,
 		'cancel': cancel,
 		'use_free_force': use_free_force,
+		'zsolt_free_force_amount': _get_zsolt_free_force_amount(player, use_free_force),
 		'spent_life_for_force': spent_life_for_force,
 	}
 	_submit_game_message(action_message)
@@ -476,6 +496,7 @@ func process_force_for_effect(action_message) -> void:
 	var treat_ultras_as_single_force = action_message['treat_ultras_as_single_force']
 	var cancel = action_message['cancel']
 	var use_free_force = action_message['use_free_force']
+	_apply_zsolt_free_force_amount(game_player, action_message)
 	var spent_life_for_force = action_message['spent_life_for_force']
 	local_game.do_force_for_effect(game_player, card_ids, treat_ultras_as_single_force, cancel, use_free_force, spent_life_for_force)
 
@@ -515,6 +536,7 @@ func do_character_action(player : Player, card_ids : Array, action_idx : int = 0
 		'card_ids': card_ids,
 		'action_idx': action_idx,
 		'use_free_force': use_free_force,
+		'zsolt_free_force_amount': _get_zsolt_free_force_amount(player, use_free_force),
 		'spent_life_for_force': spent_life_for_force,
 	}
 	_submit_game_message(action_message)
@@ -525,6 +547,7 @@ func process_character_action(action_message) -> void:
 	var card_ids = action_message['card_ids']
 	var action_idx = action_message['action_idx']
 	var use_free_force = action_message['use_free_force']
+	_apply_zsolt_free_force_amount(game_player, action_message)
 	var spent_life_for_force = action_message['spent_life_for_force']
 	local_game.do_character_action(game_player, card_ids, action_idx, use_free_force, spent_life_for_force)
 

--- a/test/unit/test_treasure.gd
+++ b/test/unit/test_treasure.gd
@@ -111,6 +111,22 @@ func test_treasure_exceed_change_cards_discard():
 	assert_eq(len(player1.hand), 2)
 	advance_turn(player2)
 
+func test_treasure_exceed_discount_survives_continuous_boost_cleanup():
+	setup_exceeded_treasure_knight()
+	position_players(player1, 3, player2, 7)
+
+	var dive_charge_id = give_player_specific_card(player1, "treasure_divecharge")
+	assert_true(game_logic.do_boost(player1, dive_charge_id, [], true))
+	advance_turn(player2)
+
+	execute_strike(player1, player2, "standard_normal_grasp", "standard_normal_grasp")
+	assert_true(player1.is_card_in_discards(dive_charge_id))
+	assert_eq(player1.free_force, 1)
+
+	advance_turn(player2)
+	assert_true(game_logic.do_move(player1, [], 4, true))
+	validate_positions(player1, 4, player2, 7)
+
 ## Anchor Launch (3~6/6/2|2/5) -- (1 Force) Hit: The opponent discards a card at
 ##     random. Then, pull until they're at range 2.
 ##     After: If this attack did not hit, advance 4, 5, or 6.

--- a/test/unit/test_zsolt.gd
+++ b/test/unit/test_zsolt.gd
@@ -94,8 +94,59 @@ func test_battle_instinct_force_pool():
 	# free_gauge = 2 (from gauge_costs_reduced_passive) reduces gauge costs.
 	assert_eq(player1.free_gauge, 2,
 		"Battle Instinct should set free_gauge to 2")
-	# The 2 force pool (zsolt_force_pool) is consumed via UI popup during
-	# PickAction or auto-set to free_force during strike resolution (game.gd).
+	# The UI selects how much of this reusable reduction applies to each payment.
+
+func test_battle_instinct_force_is_available_without_cards():
+	var boost_id = give_player_specific_card(player1, "zsolt_fanatical_purification")
+	var force_ids = give_gauge(player1, 1)
+	assert_true(game_logic.do_boost(player1, boost_id, force_ids))
+
+	player1.hand = []
+	player1.gauge = []
+	assert_eq(player1.get_available_force(), 2)
+	assert_eq(player1.get_force_with_cards([], "FORCE_FOR_EFFECT", false, true), 2)
+	assert_true(player1.can_pay_cost_with([], 2, 0, true, 0))
+
+func test_battle_instinct_cleanup_clears_its_reductions():
+	var boost_id = give_player_specific_card(player1, "zsolt_fanatical_purification")
+	var force_ids = give_gauge(player1, 1)
+	assert_true(game_logic.do_boost(player1, boost_id, force_ids))
+
+	player1.free_force = 1
+	player1.remove_from_continuous_boosts(game_logic.get_card_database().get_card(boost_id))
+	assert_eq(player1.zsolt_force_pool, 0)
+	assert_eq(player1.free_force, 0)
+	assert_eq(player1.free_gauge, 0)
+
+func test_battle_instinct_stacked_copy_survives_partial_cleanup():
+	var boost1_id = give_player_specific_card(player1, "zsolt_fanatical_purification")
+	var force_ids = give_gauge(player1, 1)
+	assert_true(game_logic.do_boost(player1, boost1_id, force_ids))
+	advance_turn(player2)
+
+	var boost2_id = give_player_specific_card(player1, "zsolt_fanatical_purification")
+	assert_true(game_logic.do_boost(player1, boost2_id, [], true))
+	assert_eq(player1.zsolt_force_pool, 4)
+	assert_eq(player1.free_gauge, 4)
+
+	player1.remove_from_continuous_boosts(game_logic.get_card_database().get_card(boost1_id))
+	assert_eq(player1.zsolt_force_pool, 2)
+	assert_eq(player1.get_available_free_force(), 2)
+	assert_eq(player1.free_gauge, 2)
+
+func test_battle_instinct_strike_cleanup_clears_its_reductions():
+	var boost_id = give_player_specific_card(player1, "zsolt_fanatical_purification")
+	var force_ids = give_gauge(player1, 1)
+	assert_true(game_logic.do_boost(player1, boost_id, force_ids))
+	advance_turn(player2)
+
+	position_players(player1, 4, player2, 5)
+	execute_strike(player1, player2, "standard_normal_grasp", "standard_normal_grasp",
+		false, false, [0, 0, 2], [])
+	assert_true(player1.is_card_in_discards(boost_id))
+	assert_eq(player1.zsolt_force_pool, 0)
+	assert_eq(player1.free_force, 0)
+	assert_eq(player1.free_gauge, 0)
 
 # ===== DEFAULT PASSIVE: normal hit -> advance/retreat/pass =====
 
@@ -383,6 +434,7 @@ func test_exceed_extra_attack_hits():
 		[[gauge_ids[0]], [extra_atk], []],  # awaken1 pay force, choose Cross, awaken2 decline
 		[])
 	validate_life(player1, 30, player2, 25)
+	assert_true(player1.is_card_in_gauge(extra_atk))
 
 func test_exceed_two_extra_attacks():
 	position_players(player1, 4, player2, 5)
@@ -408,6 +460,49 @@ func test_exceed_extra_attack_declined():
 		[[]],  # awaken: decline
 		[])
 	validate_life(player1, 30, player2, 26)
+
+func test_exceed_extra_block_uses_its_gauge_effect_on_miss():
+	position_players(player1, 4, player2, 5)
+	player1.exceeded = true
+	var extra_atk = give_player_specific_card(player1, "standard_normal_block")
+	var gauge_ids = give_gauge(player1, 1)
+
+	execute_strike(player1, player2, "standard_normal_assault", "standard_normal_dive",
+		false, false,
+		[[gauge_ids[0]], [extra_atk]],
+		[])
+	validate_life(player1, 30, player2, 26)
+	assert_true(player1.is_card_in_gauge(extra_atk))
+
+func test_exceed_extra_attack_defenses_are_cumulative():
+	position_players(player1, 4, player2, 5)
+	player1.exceeded = true
+	var focus_id = give_player_specific_card(player1, "standard_normal_focus")
+	var block_id = give_player_specific_card(player1, "standard_normal_block")
+	var gauge_ids = give_gauge(player1, 2)
+
+	execute_strike(player1, player2, "standard_normal_assault", "standard_normal_sweep",
+		false, false,
+		[[gauge_ids[0]], [focus_id], [gauge_ids[1]], [block_id], []],
+		[])
+	validate_life(player1, 28, player2, 25)
+	assert_true(player1.is_card_in_gauge(focus_id))
+	assert_true(player1.is_card_in_gauge(block_id))
+
+func test_exceed_extra_attack_transform_choices_are_independent():
+	position_players(player1, 4, player2, 5)
+	player1.exceeded = true
+	var cross_up_id = give_player_specific_card(player1, "zsolt_cross_up")
+	var blaze_id = give_player_specific_card(player1, "zsolt_blaze_of_fervour")
+	var gauge_ids = give_gauge(player1, 2)
+
+	execute_strike(player1, player2, "standard_normal_assault", "standard_normal_dive",
+		false, false,
+		[[gauge_ids[0]], [cross_up_id], 0, [gauge_ids[1]], [blaze_id], 1],
+		[])
+	validate_life(player1, 30, player2, 24)
+	assert_true(player1.is_card_in_transforms(cross_up_id))
+	assert_true(player1.is_card_in_gauge(blaze_id))
 
 # ===== TRANSFORMING AN ATTACK (choosing transform_attack) =====
 


### PR DESCRIPTION
## Summary
- preserve Treasure Knight's reusable exceeded free Force when continuous boosts are recalculated
- complete Zsolt Battle Instinct availability for engine checks, AI actions, partial UI payments, and remote synchronization
- keep Zsolt follow-up attack destination and transform state isolated per attack
- add regression coverage for stacked/removed Battle Instincts, strike cleanup, cumulative defenses, and follow-up destinations/transforms

## Testing
- Full unit suite: 1,653 tests across 101 scripts