### PR TITLE
Fix Hazama force cost cleanup

### DIFF
--- a/data/card_definitions.json
+++ b/data/card_definitions.json
@@ -10610,11 +10610,6 @@
 					"amount": 1
 				},
 				{
-					"timing": "discarded",
-					"effect_type": "remove_force_costs_reduced_passive",
-					"amount": 1
-				},
-				{
 					"timing": "now",
 					"effect_type": "choice",
 					"choice": [
@@ -10657,11 +10652,6 @@
 				{
 					"timing": "now",
 					"effect_type": "force_costs_reduced_passive",
-					"amount": 1
-				},
-				{
-					"timing": "discarded",
-					"effect_type": "remove_force_costs_reduced_passive",
 					"amount": 1
 				},
 				{

--- a/scenes/core/local_game.gd
+++ b/scenes/core/local_game.gd
@@ -3018,7 +3018,7 @@ func handle_strike_effect(card_id : int, effect, performing_player : Player):
 			performing_player.force_cost_reduction += effect['amount']
 			_append_log_full(Enums.LogType.LogType_Effect, performing_player, "now has their force costs reduced by %s!" % performing_player.force_cost_reduction)
 		StrikeEffects.RemoveForceCostsReducedPassive:
-			performing_player.force_cost_reduction -= effect['amount']
+			performing_player.force_cost_reduction = max(0, performing_player.force_cost_reduction - effect['amount'])
 			if performing_player.force_cost_reduction == 0:
 				_append_log_full(Enums.LogType.LogType_Effect, performing_player, "no longer has their force costs reduced.")
 			else:

--- a/test/unit/test_hazama.gd
+++ b/test/unit/test_hazama.gd
@@ -401,6 +401,22 @@ func test_hazama_hungrycoils_force_reduce_dont_strike_move():
 	assert_true(game_logic.do_move(player1, [], 4))
 	advance_turn(player2)
 
+func test_hazama_force_reduction_cleanup_does_not_increase_ua_cost():
+	give_player_specific_card(player1, "hazama_hungrycoils", TestCardId3)
+	assert_true(game_logic.do_boost(player1, TestCardId3))
+	assert_true(game_logic.do_choice(player1, 1)) # Skip striking
+	assert_eq(player1.force_cost_reduction, 1)
+
+	var boost = game_logic.get_card_database().get_card(TestCardId3)
+	player1.remove_from_continuous_boosts(boost)
+	assert_eq(player1.force_cost_reduction, 0)
+
+	advance_turn(player2)
+	give_specific_cards(player1, "standard_normal_assault", player2, "standard_normal_assault")
+	do_and_validate_strike(player1, TestCardId1)
+	assert_eq(game_logic.decision_info.type, Enums.DecisionType.DecisionType_ForceForEffect)
+	assert_true(game_logic.do_force_for_effect(player1, [player1.hand[0].id], false))
+
 func test_hazama_hungrycoils_force_reduce_dont_strike_move_2():
 	position_players(player1, 3, player2, 7)
 	give_player_specific_card(player1, "hazama_hungrycoils", TestCardId3)
@@ -549,4 +565,3 @@ func test_hazama_v_sagat_crit_mid_opponent_sets_first():
 	# Attack should now play out, because devouring fang is free
 	validate_positions(player1, 4, player2, 5)
 	validate_life(player1, 28, player2, 30)
-


### PR DESCRIPTION
## Summary
- remove Hazama's duplicate discarded cost-reduction cleanup
- prevent explicit force-cost reduction removal from going below zero
- verify Ouroboros costs one force after the boost leaves play

## Testing
- focused Hazama GUT suite (24 passing)