### PR TITLE
Fix private decision UI regressions

### DIFF
--- a/globals/global_settings.gd
+++ b/globals/global_settings.gd
@@ -5,7 +5,7 @@ signal settings_loaded
 const ReleaseLoggingEnabled = false # If true, log even on release builds.
 const UseAzureServerAlways = true # If true, always defaults to the azure server.
 var MuteEmotes = false
-const ClientVersionString : String = "260719.1400" # YYMMDD.HHMM
+const ClientVersionString : String = "260721.1000" # YYMMDD.HHMM
 const ReplayVersion : int = 1
 
 const CharacterBanlist = ['carmine']

--- a/scenes/core/game_wrapper.gd
+++ b/scenes/core/game_wrapper.gd
@@ -78,6 +78,9 @@ func _get_player(id):
 func get_game_state() -> Enums.GameState:
 	return current_game.get_game_state()
 
+func has_active_strike() -> bool:
+	return current_game != null and current_game.has_active_strike()
+
 func get_active_player() -> Enums.PlayerId:
 	return current_game.get_active_player()
 

--- a/scenes/core/local_game.gd
+++ b/scenes/core/local_game.gd
@@ -167,6 +167,9 @@ func change_game_state(new_state : Enums.GameState):
 func get_game_state() -> Enums.GameState:
 	return game_state
 
+func has_active_strike() -> bool:
+	return active_strike != null
+
 func get_decision_info() -> DecisionInfo:
 	return decision_info
 
@@ -9221,7 +9224,11 @@ func do_strike(
 				return false
 		elif not wild_strike and not performing_player.is_card_in_hand(card_id):
 			if performing_player.is_card_in_set_aside(card_id):
-				pass
+				var face_attack_card = performing_player.get_face_attack_card()
+				if performing_player.deck_def.get("id") != "eugenia" or \
+						not face_attack_card or face_attack_card.id != card_id:
+					printlog("ERROR: Tried to strike with a set-aside card.")
+					return false
 			elif performing_player.is_card_in_continuous_boosts(card_id):
 				strike_from_boosts = true
 				var card = card_db.get_card(card_id)

--- a/scenes/core/remote_game.gd
+++ b/scenes/core/remote_game.gd
@@ -126,6 +126,9 @@ func _on_remote_player_quit(_is_disconnect : bool):
 func get_game_state() -> Enums.GameState:
 	return local_game.get_game_state()
 
+func has_active_strike() -> bool:
+	return local_game.has_active_strike()
+
 func get_active_player() -> Enums.PlayerId:
 	return local_game.get_active_player()
 

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -1207,7 +1207,9 @@ func can_select_card(card):
 			if select_gauge_valid_card_types:
 				valid_type = logic_card.definition['type'] in select_gauge_valid_card_types
 			return in_gauge and valid_id and valid_type and len(selected_cards) < select_card_require_max
-		UISubState.UISubState_SelectCards_StrikeCard, UISubState.UISubState_SelectCards_StrikeResponseCard, UISubState.UISubState_SelectCards_OpponentSetsFirst_StrikeCard, UISubState.UISubState_SelectCards_OpponentSetsFirst_StrikeResponseCard, UISubState.UISubState_SelectCards_Mulligan:
+		UISubState.UISubState_SelectCards_Mulligan:
+			return in_hand
+		UISubState.UISubState_SelectCards_StrikeCard, UISubState.UISubState_SelectCards_StrikeResponseCard, UISubState.UISubState_SelectCards_OpponentSetsFirst_StrikeCard, UISubState.UISubState_SelectCards_OpponentSetsFirst_StrikeResponseCard:
 			if in_player_boosts:
 				var card_db = game_wrapper.get_card_database()
 				var logic_card = card_db.get_card(card.card_id)
@@ -1216,7 +1218,11 @@ func can_select_card(card):
 				if 'may_set_from_boost' in logic_card.definition and logic_card.definition['may_set_from_boost']:
 					return true
 				return false
-			return in_hand or in_set_aside
+			var face_attack_card = game_wrapper.get_face_attack_card(Enums.PlayerId.PlayerId_Player)
+			var is_eugenia_wonderland_card = in_set_aside and \
+				game_wrapper.get_player_deck_definition(Enums.PlayerId.PlayerId_Player).get("id") == "eugenia" and \
+				face_attack_card and face_attack_card.id == card.card_id
+			return in_hand or is_eugenia_wonderland_card
 		UISubState.UISubState_SelectCards_StrikeCard_FromGauge:
 			return in_gauge
 		UISubState.UISubState_SelectCards_StrikeCard_FromSealed:
@@ -1945,12 +1951,9 @@ func _on_choose_from_topdeck(event):
 	var action_choices = decision_info.action
 	var can_pass = decision_info.can_pass
 	var look_amount = decision_info.amount
-	if player == Enums.PlayerId.PlayerId_Player or not game_wrapper.is_ai_game():
-		# Online: each client maps itself as Player, only shows own choices
-		# Local hotseat / AI: show interface for both players
+	if player == Enums.PlayerId.PlayerId_Player and not observer_mode:
 		begin_choose_from_topdeck(action_choices, look_amount, can_pass, player)
-	else:
-		# AI opponent picks randomly
+	elif game_wrapper.is_ai_game():
 		ai_choose_from_topdeck(action_choices, look_amount, can_pass)
 
 func get_string_for_action_choice(choice):
@@ -2827,7 +2830,7 @@ func begin_generate_force_selection(amount, can_cancel : bool = true, wild_swing
 	var p = game_wrapper._get_player(Enums.PlayerId.PlayerId_Player)
 	# During strike resolution, auto-use the pool to avoid await freeze
 	# But skip if caller already set free_force (skip_zsolt_popup = true)
-	var in_strike = game_wrapper.current_game and game_wrapper.current_game.active_strike != null
+	var in_strike = game_wrapper.has_active_strike()
 	if p.zsolt_force_pool > 0 and in_strike and not skip_zsolt_popup:
 		p.free_force = p.zsolt_force_pool if amount <= 0 else min(p.zsolt_force_pool, amount)
 	if p.zsolt_force_pool > 0 and not skip_zsolt_popup and not in_strike:
@@ -4165,7 +4168,7 @@ func _update_buttons(no_number_picker_update : bool = false):
 	var cancel_text = "Cancel"
 	if not preparing_character_action:
 		match ui_sub_state:
-			UISubState.UISubState_SelectCards_BoostCancel, UISubState.UISubState_SelectCards_Mulligan, UISubState.UISubState_SelectCards_DiscardCardsToGauge, UISubState.UISubState_SelectCards_ChooseDiscardToDestination:
+			UISubState.UISubState_SelectCards_BoostCancel, UISubState.UISubState_SelectCards_Mulligan, UISubState.UISubState_SelectCards_ForceForEffect, UISubState.UISubState_SelectCards_DiscardCardsToGauge, UISubState.UISubState_SelectCards_ChooseDiscardToDestination:
 				cancel_text = "Pass"
 			UISubState.UISubState_SelectCards_ChooseBoostsToSustain, UISubState.UISubState_SelectCards_ChooseFromTopdeck, UISubState.UISubState_SelectCards_ChooseOpponentCardToDiscard:
 				cancel_text = "Pass"
@@ -5042,11 +5045,6 @@ func _on_instructions_cancel_button_pressed():
 			deselect_all_cards()
 			close_popout()
 			success = game_wrapper.submit_force_for_effect(Enums.PlayerId.PlayerId_Player, [], false, true, false)
-			if success:
-				popout_instruction_info = null
-				change_ui_state(UIState.UIState_PickTurnAction, UISubState.UISubState_None)
-				_update_buttons()
-				return
 		UISubState.UISubState_SelectCards_GaugeForArmor:
 			deselect_all_cards()
 			close_popout()

--- a/test/unit/test_arakune.gd
+++ b/test/unit/test_arakune.gd
@@ -70,6 +70,12 @@ func after_each():
 	game_logic.free()
 	gut.p("ran teardown", 2)
 
+func test_cannot_strike_with_set_aside_card():
+	assert_gt(player1.set_aside_cards.size(), 0)
+	var set_aside_card_id = player1.set_aside_cards[0].id
+	assert_false(game_logic.do_strike(player1, set_aside_card_id, false, -1))
+	assert_true(player1.is_card_in_set_aside(set_aside_card_id))
+
 func before_all():
 	gut.p("ran run setup", 2)
 

--- a/test/unit/test_eugenia.gd
+++ b/test/unit/test_eugenia.gd
@@ -296,6 +296,14 @@ func test_wonderland_replace_returns_old_card_to_opponent_discard():
 
 # ===== WONDERLAND FACE ATTACK: +1 Power / +1 Speed while exceeded =====
 
+func test_wonderland_placeholder_cannot_strike():
+	var gauge_ids = give_gauge(player1, 6)
+	assert_true(game_logic.do_exceed(player1, gauge_ids))
+	advance_turn(player2)
+	var placeholder_id = player1.set_aside_cards[0].id
+	assert_false(game_logic.do_strike(player1, placeholder_id, false, -1))
+	assert_true(player1.is_card_in_set_aside(placeholder_id))
+
 func test_wonderland_face_attack_bonus():
 	var gauge_ids = give_gauge(player1, 6)
 	assert_true(game_logic.do_exceed(player1, gauge_ids))


### PR DESCRIPTION
## Summary
- hide private top-deck choice windows from opponents and observers
- restrict direct set-aside strikes to valid Eugenia Wonderland attacks
- make active-strike detection safe for remote games
- preserve server-driven UI state when passing optional force effects
- prevent set-aside cards from being selected during mulligans

## Tests
- `test_arakune`: 27 passing
- `test_eugenia`: 26 passing
- `test_zsolt`: 36 passing